### PR TITLE
Improve LinkedIn connection reliability and messaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,21 @@ data/
 scripts/*
 !scripts/mirror-ee.js
 !scripts/strip-mirrored-pages.js
+# Also KEEP the live LinkedIn retest harness: it has to run INSIDE the container,
+# where the pinned Chromium and the mounted /data/linki.db session live — running
+# it on the host would use a different browser fingerprint. retest-connect.ts is
+# the entrypoint; the two test-* files are the ESM resolve hooks it (and
+# `npm test`) load via --import. See `npm run retest:connect`.
+!scripts/retest-connect.ts
+!scripts/test-setup.mjs
+!scripts/test-resolve-hooks.mjs
+
+# Local scratch diagnostics. Superseded by scripts/retest-connect.ts, and they
+# import via absolute /app/... paths that break `next build`'s typecheck.
+/diag.ts
+/invite-diag.ts
+/whoami.ts
+*.bak
 mcp/
 playwright-browsers/
 .env*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 services:
   linki:
-    image: moaljumaa/linki:latest
+# image: moaljumaa/linki:latest
     # To build from source instead: comment out image above and uncomment below
-    # build: .
+    build: .
     ports:
       - "127.0.0.1:${PORT:-3456}:3000"
     volumes:

--- a/lib/linkedin/connect.test.ts
+++ b/lib/linkedin/connect.test.ts
@@ -1,0 +1,367 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "playwright";
+import {
+  sendConnectionRequest,
+  AlreadyConnectedError,
+  PendingInviteError,
+  InviteUiError,
+  InviteNotSentError,
+  SessionExpiredError,
+} from "./connect";
+
+// ─── fake Page ───────────────────────────────────────────────────────────────
+// connect.ts drives Playwright through a small, fixed set of semantic
+// selectors. Rather than emulating a DOM, the fake describes each page
+// abstractly and maps those selectors onto it — so a test reads as "the
+// profile offers Connect, the invite modal has no Send button" rather than as
+// markup.
+
+interface PageState {
+  /** null = the <h1>/componentkey top card isn't present at all */
+  topCard: { text: string; composeLinks: number; connectCtas: number; composeHref?: string | null;
+    /** visible <p> elements; the degree badge is its own <p>· 1st</p> */
+    paras?: string[] } | null;
+  /** href of the target's OWN Connect link, keyed by their vanityName */
+  ownConnectHref: string | null;
+  pendingBadges: number;
+  sendButton: boolean;
+  dialogText: string;
+  limitPopup: boolean;
+  errorToast: string | null;
+  /** vanityNames the sent-invitations manager reports as pending */
+  sentInvitations: string[] | null;
+}
+
+const blank: PageState = {
+  topCard: null,
+  ownConnectHref: null,
+  pendingBadges: 0,
+  sendButton: false,
+  dialogText: "",
+  limitPopup: false,
+  errorToast: null,
+  sentInvitations: null,
+};
+
+interface Ctx {
+  sendClicked: boolean;
+  clicks: string[];
+}
+
+type Route = { match: RegExp; state: (ctx: Ctx) => Partial<PageState> };
+
+class FakeLocator {
+  page: FakePage;
+  sel: string;
+  scope: "page" | "topCard";
+
+  hasText: string | RegExp | null = null;
+
+  constructor(page: FakePage, sel: string, scope: "page" | "topCard" = "page") {
+    this.page = page;
+    this.sel = sel;
+    this.scope = scope;
+  }
+
+  private matches(): number {
+    const s = this.state;
+    const sel = this.sel;
+    if (this.scope === "topCard") {
+      if (!s.topCard) return 0;
+      if (sel === "p" || sel === "p:visible") {
+        const f = this.hasText;
+        return (s.topCard.paras ?? []).filter(t => {
+          const n = t.replace(/\s+/g, " ").trim();
+          return f === null ? true : typeof f === "string" ? n.includes(f) : f.test(n);
+        }).length;
+      }
+      if (sel.includes("/messaging/compose")) return s.topCard.composeLinks;
+      if (sel.includes("to connect")) return s.topCard.connectCtas;
+      return 0;
+    }
+    if (sel.includes('componentkey$="Topcard"')) return s.topCard ? 1 : 0;
+    if (sel.startsWith("main section")) return 0; // legacy layout not present
+    if (sel.includes("custom-invite")) return s.ownConnectHref ? 1 : 0;
+    if (sel.includes("Pending")) return s.pendingBadges;
+    if (sel.includes("ip-fuse-limit-alert__warning")) return s.limitPopup ? 1 : 0;
+    if (sel.includes("artdeco-toast-item-type")) return s.errorToast ? 1 : 0;
+    if (sel.includes("Send without") || sel.includes("Send now")) return s.sendButton ? 1 : 0;
+    if (sel.includes('role="dialog"')) return s.dialogText ? 1 : 0;
+    if (sel.includes('aria-label="More"')) return 0;
+    if (sel.includes("menuitem")) return 0;
+    return 0;
+  }
+
+  private get state(): PageState {
+    return this.page.state;
+  }
+
+  async count(): Promise<number> {
+    return this.matches();
+  }
+  first(): FakeLocator {
+    return this;
+  }
+  nth(): FakeLocator {
+    return this;
+  }
+  filter(o?: { hasText?: string | RegExp }): FakeLocator {
+    if (o?.hasText === undefined) return this;
+    const l = new FakeLocator(this.page, this.sel, this.scope);
+    l.hasText = o.hasText;
+    return l;
+  }
+  locator(sel: string): FakeLocator {
+    return new FakeLocator(this.page, sel, "topCard");
+  }
+  async waitFor(): Promise<void> {
+    if (this.matches() === 0) throw new Error(`Timeout waiting for ${this.sel}`);
+  }
+  /**
+   * No-op. Production uses this only to scroll the CTA clear of the sticky
+   * header; the fake has no viewport, so there is nothing to model.
+   */
+  async evaluate(): Promise<unknown> {
+    return undefined;
+  }
+  async click(): Promise<void> {
+    if (this.matches() === 0) throw new Error(`cannot click ${this.sel}`);
+    this.page.ctx.clicks.push(this.sel);
+    if (this.sel.includes("Send without") || this.sel.includes("Send now")) {
+      this.page.ctx.sendClicked = true;
+    }
+  }
+  async getAttribute(name: string): Promise<string | null> {
+    if (name !== "href") return null;
+    // Compose hrefs are modelled because visitProfile() extracts the messaging
+    // URN from them. They are NOT a connection signal — both connections and
+    // non-connections carry profileUrn (verified live Aug 2026).
+    if (this.sel.includes("/messaging/compose")) return this.state.topCard?.composeHref ?? null;
+    return this.state.ownConnectHref;
+  }
+  async innerText(): Promise<string> {
+    const isCard = this.scope === "topCard" || this.sel.includes('componentkey$="Topcard"');
+    if (isCard) {
+      if (!this.state.topCard) throw new Error("no top card");
+      return this.state.topCard.text;
+    }
+    if (this.sel.includes('role="dialog"')) return this.state.dialogText;
+    if (this.sel.includes("artdeco-toast-item-type")) return this.state.errorToast ?? "";
+    return "";
+  }
+}
+
+class FakePage {
+  url_ = "about:blank";
+  state: PageState = { ...blank };
+  ctx: Ctx = { sendClicked: false, clicks: [] };
+  navigations: string[] = [];
+  routes: Route[];
+
+  constructor(routes: Route[]) {
+    this.routes = routes;
+  }
+
+  url(): string {
+    return this.url_;
+  }
+  async goto(url: string): Promise<void> {
+    this.navigations.push(url);
+    this.url_ = url;
+    const route = this.routes.find(r => r.match.test(url));
+    this.state = { ...blank, ...(route ? route.state(this.ctx) : {}) };
+  }
+  waits = 0;
+  async waitForTimeout(): Promise<void> {
+    this.waits++;
+  }
+  locator(sel: string): FakeLocator {
+    return new FakeLocator(this, sel);
+  }
+  // Only reached via scrapePendingInvitationVanityNames()
+  async evaluate(fn: () => unknown): Promise<unknown> {
+    const src = fn.toString();
+    if (src.includes("scrollTop")) return undefined;
+    if (src.includes(".length")) return 1;
+    return this.state.sentInvitations ?? [];
+  }
+}
+
+const PROFILE = "https://www.linkedin.com/in/jamil-khan-55a621346/";
+const VANITY = "jamil-khan-55a621346";
+const INVITE_HREF = `/preload/custom-invite/?vanityName=${VANITY}`;
+
+const connectableProfile = (): Partial<PageState> => ({
+  topCard: { text: "Jamil Khan\n94 connections", composeLinks: 1, connectCtas: 1 },
+  ownConnectHref: INVITE_HREF,
+});
+
+const makePage = (routes: Route[]) => new FakePage(routes) as unknown as Page;
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+test("throws instead of reporting success when the Send button is missing", async () => {
+  const page = makePage([
+    { match: /\/in\//, state: connectableProfile },
+    // Invite page renders, but with no Send button (the regression: the old
+    // code found 0 send buttons and returned normally, so the runner logged
+    // "Connection request sent" for an invitation that never happened).
+    { match: /custom-invite/, state: () => ({ dialogText: "Add a note to your invitation?" }) },
+  ]);
+
+  await assert.rejects(() => sendConnectionRequest(page, PROFILE), InviteUiError);
+});
+
+test("a missing Send button never reaches the send/verify stage", async () => {
+  const fake = new FakePage([
+    { match: /\/in\//, state: connectableProfile },
+    { match: /custom-invite/, state: () => ({}) },
+  ]);
+  await assert.rejects(() => sendConnectionRequest(fake as unknown as Page, PROFILE));
+  assert.equal(fake.ctx.sendClicked, false);
+  // Opening the invite UI now clicks the person's own Connect CTA first, so the
+  // guarantee under test is narrower than "nothing was clicked": no Send-shaped
+  // control may ever be clicked when no Send button exists.
+  assert.ok(
+    !fake.ctx.clicks.some(sel => /Send without|Send now|Send invitation/i.test(sel)),
+    `no Send control may be clicked, got ${JSON.stringify(fake.ctx.clicks)}`
+  );
+});
+
+test("throws when Send was clicked but the invitation is not pending afterwards", async () => {
+  const page = makePage([
+    {
+      match: /\/in\//,
+      // Still offering Connect after the click == LinkedIn recorded nothing.
+      state: connectableProfile,
+    },
+    { match: /custom-invite/, state: () => ({ sendButton: true, dialogText: "Add a note to your invitation?" }) },
+    { match: /invitation-manager/, state: () => ({ sentInvitations: ["someone-else-123"] }) },
+  ]);
+
+  await assert.rejects(() => sendConnectionRequest(page, PROFILE), InviteNotSentError);
+});
+
+test("returns normally once the profile shows Pending", async () => {
+  const page = makePage([
+    {
+      match: /\/in\//,
+      state: ctx =>
+        ctx.sendClicked
+          ? { topCard: { text: "Jamil Khan\nPending", composeLinks: 1, connectCtas: 0 }, pendingBadges: 1 }
+          : connectableProfile(),
+    },
+    { match: /custom-invite/, state: () => ({ sendButton: true, dialogText: "Add a note to your invitation?" }) },
+  ]);
+
+  await sendConnectionRequest(page, PROFILE);
+});
+
+test("falls back to the sent-invitations list when the profile shows no Pending badge", async () => {
+  const page = makePage([
+    {
+      match: /\/in\//,
+      state: ctx =>
+        ctx.sendClicked
+          ? { topCard: { text: "Jamil Khan", composeLinks: 1, connectCtas: 0 } }
+          : connectableProfile(),
+    },
+    { match: /custom-invite/, state: () => ({ sendButton: true, dialogText: "Add a note to your invitation?" }) },
+    { match: /invitation-manager/, state: () => ({ sentInvitations: [VANITY] }) },
+  ]);
+
+  await sendConnectionRequest(page, PROFILE);
+});
+
+test("throws SessionExpiredError when LinkedIn serves the login interstitial", async () => {
+  // The concrete trigger behind the reported incident: a stale li_at makes
+  // /preload/custom-invite bounce to /uas/login, where no Send button exists.
+  const fake = new FakePage([]);
+  const page = fake as unknown as Page;
+  fake.goto = async (url: string) => {
+    fake.navigations.push(url);
+    fake.url_ = `https://www.linkedin.com/uas/login?session_redirect=${encodeURIComponent(url)}`;
+    fake.state = { ...blank };
+  };
+
+  await assert.rejects(() => sendConnectionRequest(page, PROFILE), SessionExpiredError);
+});
+
+test("fails fast on an authwall instead of polling it for 45s", async () => {
+  // An authwall never self-clears, so waiting it out just stalls every target.
+  const fake = new FakePage([]);
+  fake.goto = async (url: string) => {
+    fake.navigations.push(url);
+    fake.url_ = `https://www.linkedin.com/authwall?sessionRedirect=${encodeURIComponent(url)}`;
+    fake.state = { ...blank };
+  };
+
+  await assert.rejects(() => sendConnectionRequest(fake as unknown as Page, PROFILE), SessionExpiredError);
+  assert.equal(fake.waits, 0, "should not poll an authwall at all");
+});
+
+test("catches an authwall redirect that fires after domcontentloaded", async () => {
+  // LinkedIn issues the authwall bounce client-side, so the URL still looks
+  // like the profile at the instant goto() resolves.
+  const fake = new FakePage([]);
+  let pendingRedirect: string | null = null;
+  fake.goto = async (url: string) => {
+    fake.navigations.push(url);
+    fake.url_ = url;
+    fake.state = { ...blank, ...connectableProfile() };
+    pendingRedirect = `https://www.linkedin.com/authwall?sessionRedirect=${encodeURIComponent(url)}`;
+  };
+  fake.waitForTimeout = async () => {
+    fake.waits++;
+    if (pendingRedirect) {
+      fake.url_ = pendingRedirect;
+      pendingRedirect = null;
+      fake.state = { ...blank };
+    }
+  };
+
+  await assert.rejects(() => sendConnectionRequest(fake as unknown as Page, PROFILE), SessionExpiredError);
+});
+
+test("throws PendingInviteError when an invitation is already pending", async () => {
+  const page = makePage([
+    {
+      match: /\/in\//,
+      state: () => ({ topCard: { text: "Jamil Khan\nPending", composeLinks: 0, connectCtas: 0 }, pendingBadges: 1 }),
+    },
+  ]);
+
+  await assert.rejects(() => sendConnectionRequest(page, PROFILE), PendingInviteError);
+});
+
+test("throws AlreadyConnectedError for a 1st-degree connection", async () => {
+  const page = makePage([
+    {
+      match: /\/in\//,
+      state: () => ({ topCard: { text: "Jamil Khan\n1st\n94 connections", composeLinks: 1, connectCtas: 0,
+        paras: ["Jamil Khan", "· 1st"],
+        composeHref: "/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3AACoAAReal" } }),
+    },
+  ]);
+
+  await assert.rejects(() => sendConnectionRequest(page, PROFILE), AlreadyConnectedError);
+});
+
+test("a Message link in the top card does not imply connected while Connect is offered", async () => {
+  // Regression guard for the Jul 2026 incident class: the current layout shows
+  // /messaging/compose on the top card of NON-connections too, so the compose
+  // link alone must not short-circuit into AlreadyConnectedError.
+  const page = makePage([
+    {
+      match: /\/in\//,
+      state: ctx =>
+        ctx.sendClicked
+          ? { topCard: { text: "Jamil Khan\nPending", composeLinks: 1, connectCtas: 0 }, pendingBadges: 1 }
+          : connectableProfile(),
+    },
+    { match: /custom-invite/, state: () => ({ sendButton: true, dialogText: "Add a note to your invitation?" }) },
+  ]);
+
+  await sendConnectionRequest(page, PROFILE);
+});

--- a/lib/linkedin/connect.ts
+++ b/lib/linkedin/connect.ts
@@ -1,89 +1,448 @@
-import type { Page } from "playwright";
+import type { Locator, Page } from "playwright";
+import { scrapePendingInvitationVanityNames } from "./pending-invitations";
 
 export class WeeklyLimitError extends Error {}
 export class AlreadyConnectedError extends Error {}
 export class PendingInviteError extends Error {}
+/** The invitation UI could not be reached/completed — nothing was sent. */
+export class InviteUiError extends Error {}
+/** Send was clicked but LinkedIn never showed the invitation as sent. */
+export class InviteNotSentError extends Error {}
+/** The stored session is no longer signed in — LinkedIn served login/authwall. */
+export class SessionExpiredError extends Error {}
+
+// LinkedIn bounces un/half-authenticated navigations through these. Landing
+// here is NOT a transient render delay — it means the page we're looking at is
+// not the app, so no selector on it means anything.
+//
+// The two kinds behave differently and must not be conflated:
+//  - the login interstitial self-clears (see settleAuthRedirect), so it's polled;
+//  - an authwall/checkpoint never self-clears, so polling it just burns 45s per
+//    target. It fails fast instead.
+const LOGIN_INTERSTITIAL_RE = /\/(uas\/)?login\b/;
+const HARD_WALL_RE = /\/authwall\b|\/checkpoint\//;
+const AUTH_WALL_URL_RE = new RegExp(`${LOGIN_INTERSTITIAL_RE.source}|${HARD_WALL_RE.source}`);
+
+// The person's own primary CTA. Semantic on both counts: the accessible name
+// ("Invite <Name> to connect") and the href's vanityName both identify WHO the
+// button acts on, so neither depends on LinkedIn's hashed CSS classes.
+const CONNECT_CTA = 'a[aria-label*="to connect"], button[aria-label*="to connect"], a[href*="custom-invite"]';
+
+// Invite modal. Confirmed live (Aug 2026): <div role="dialog" class="… send-invite"
+// aria-labelledby="send-invite-modal"> with an actionbar holding
+// <button aria-label="Add a note"> and <button aria-label="Send without a note">.
+const INVITE_DIALOG = '[role="dialog"]:visible, dialog[open]';
+
+// The profile card's overflow button. Scoped to the top card by the caller, so
+// it can never resolve to the nav bar's, a post's, or a recommendation's.
+const MORE_BUTTON = 'button[aria-label="More"], button[aria-label^="More actions"]';
+const OPEN_MENU = '[role="menu"]:visible';
+
+// The 1st-degree badge, as it actually exists (verified live Aug 2026).
+//
+// A connected card renders the degree as its OWN element — <p>· 1st</p> — while
+// a non-connected card has no degree element at all. LinkedIn also ships hidden
+// variants: the connected specimen carried <p>· 2nd</p> hidden beside the
+// visible <p>· 1st</p>, so visibility is part of the contract.
+//
+// Matching must be element-level and anchored. The previous /\b1st\b/ over the
+// whole card's innerText also matched ordinary profile prose — "Partner at 1st
+// Round Capital", "1st Lieutenant", "Ranked 1st in EMEA" — any of which would
+// have marked a stranger connected, skipped their invitation, and (via the
+// runner's degree=1 stamp) authorised a message to them.
+//
+// There is no semantic hook to use instead: the badge carries no role, no
+// aria-label, no data-* and no componentkey, and its classes are hashed.
+const DEGREE_BADGE = "p:visible";
+const RE_FIRST_DEGREE = /^·?\s*1st$/;
+
+/** True only when the person's own card shows a visible 1st-degree badge. */
+export async function hasFirstDegreeBadge(topCard: Locator | null): Promise<boolean> {
+  if (!topCard) return false;
+  return (await topCard.locator(DEGREE_BADGE).filter({ hasText: RE_FIRST_DEGREE }).count()) > 0;
+}
+
+// Pending affordance on the person's own card. Scoped by the caller — page-wide
+// it also matches sidebar modules belonging to other people.
+const PENDING_IN_CARD = '[aria-label*="Pending"], button[aria-label*="Pending"]';
+
+// More-menu items, matched SEMANTICALLY. Observed live Aug 2026: every item has
+// aria-label=null and its label nested in a child <div>, so `:text-is("Connect")`
+// and getByRole(name) both match nothing, while `:has-text("Connect")` is a
+// substring and also matches "Remove connection" / "Connections".
+//
+// The Connect item is an anchor carrying the invitation href, which names the
+// target: /preload/custom-invite/?vanityName=<vanity>. That is target-specific
+// and language-independent, so it is the primary selector.
+const menuConnectFor = (vanity: string) =>
+  `a[role="menuitem"][href*="custom-invite"][href*="vanityName=${vanity}"]`;
+// Fallback discriminators. componentkey is semantic; the anchored text regexes
+// are a documented last resort for items with neither href nor componentkey,
+// and are anchored so "Remove connection"/"Connections" can never match.
+const MENU_PENDING_KEY = '[role="menuitem"][componentkey$="_pending"]';
+const MENU_ITEM = '[role="menuitem"]';
+const RE_PENDING = /^Pending$/i;
+const RE_REMOVE_CONNECTION = /^Remove connection$/i;
+const SEND_BUTTON =
+  'button[aria-label*="Send without"], button[aria-label*="Send invitation"]:not([aria-label*="note"]), button:has-text("Send now"), button:has-text("Send without a note")';
+
+/** `jamil-khan-55a621346` from any form of profile URL. */
+export function vanityNameOf(linkedinUrl: string): string | null {
+  return linkedinUrl.match(/\/in\/([^/?#]+)/)?.[1]?.toLowerCase() ?? null;
+}
 
 /**
- * Sends a LinkedIn connection request without a note.
- * Navigates to the profile page and clicks the Connect button.
- * Throws WeeklyLimitError if the weekly limit popup appears.
- * Throws AlreadyConnectedError / PendingInviteError if already in that state.
+ * LinkedIn re-mints an expired `li_at` from the `li_rm` remember-me cookie via
+ * an interstitial ("We're signing you in") that self-redirects back to the
+ * requested page after a few seconds. Wait that out rather than reading the
+ * login page's DOM. Returns false if we're still stuck on login/authwall.
  */
-export async function sendConnectionRequest(page: Page, linkedinUrl: string): Promise<void> {
-  await page.goto(linkedinUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
-  await page.waitForTimeout(2000 + Math.random() * 1000);
+const AUTH_POLL_MS = 1500;
+async function settleAuthRedirect(page: Page, timeoutMs = 45000): Promise<boolean> {
+  // Paced by page.waitForTimeout rather than wall-clock so the loop is driven
+  // by the page, not by Date.now().
+  for (let i = 0; i < Math.ceil(timeoutMs / AUTH_POLL_MS); i++) {
+    const url = page.url();
+    if (HARD_WALL_RE.test(url)) return false; // never self-clears — don't wait it out
+    if (!LOGIN_INTERSTITIAL_RE.test(url)) return true;
+    await page.waitForTimeout(AUTH_POLL_MS);
+  }
+  return !AUTH_WALL_URL_RE.test(page.url());
+}
 
-  // Already connected? Primary signal: presence of the profile's "Message" link
-  // (only shown to 1st-degree connections) — an href attribute, not a CSS class
-  // or translated text, so it survives LinkedIn's class-name hashing and non-
-  // English UI languages. Falls back to the old text-scrape for accounts/layouts
-  // where that link isn't found as a plain <a href>.
+export async function gotoAuthenticated(page: Page, url: string): Promise<void> {
+  await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
+
+  // The bounce to /authwall is issued client-side, AFTER domcontentloaded — so
+  // checking the URL only once, right after goto(), still sees the requested
+  // page and waves the redirect through. Settle, give the redirect a moment to
+  // fire, then confirm we really are on the app.
+  let onApp = await settleAuthRedirect(page);
+  if (onApp) {
+    await page.waitForTimeout(2500);
+    onApp = await settleAuthRedirect(page);
+  }
+
+  if (!onApp) {
+    throw new SessionExpiredError(
+      `LinkedIn served a login/authwall page instead of ${url} (stuck at ${page.url()}) — the account session needs re-authentication`
+    );
+  }
+}
+
+/**
+ * The visited person's OWN intro/top card.
+ *
+ * Everything read for already-connected / pending detection MUST be scoped
+ * here: a page-wide search also matches "Message" links and "1st" badges
+ * belonging to OTHER people rendered elsewhere on the page (sidebar modules
+ * like "People also viewed"). For a non-connected target that false-positived
+ * AlreadyConnected, which skipped the real invite AND (via the message step
+ * that follows) sent a message to a random unrelated 1st-degree connection
+ * instead of the target — see CLAUDE.md / memory for the Jul 2026 incident.
+ *
+ * Two layouts are live in the wild, tried in order:
+ *  - Current SDUI layout: the card carries componentkey="…<profileId>Topcard".
+ *    This layout has NO <h1> at all (the name is an <h2>), which is why the
+ *    old <h1>-anchored locator silently matched nothing on it.
+ *  - Legacy layout: the section containing the page's own <h1> name heading.
+ * Both are structural/attribute-based, so they survive class-name hashing.
+ */
+export async function findTopCard(page: Page): Promise<Locator | null> {
+  const candidates = [
+    page.locator('[componentkey$="Topcard"]').first(),
+    page.locator("main section").filter({ has: page.locator("h1") }).first(),
+  ];
+  for (const candidate of candidates) {
+    if ((await candidate.count()) > 0) return candidate;
+  }
+  return null;
+}
+
+/**
+ * The target's own Connect link, identified by the vanityName in its href
+ * rather than by position in the DOM. Sidebar recommendation cards render the
+ * same markup for OTHER people, but always with THEIR vanityName, so this
+ * cannot pick up a stranger's CTA the way a positional `.first()` can.
+ */
+function ownConnectLink(page: Page, vanity: string): Locator {
+  return page.locator(`a[href*="custom-invite"][href*="vanityName=${vanity}"]`).first();
+}
+
+/**
+ * Throws if LinkedIn already considers this person connected or invited.
+ *
+ * A Connect CTA on the person's own card is positive proof from LinkedIn that
+ * they are neither — so it short-circuits the weaker heuristics below. That
+ * ordering matters: on the current layout the top card renders a
+ * `/messaging/compose` link even for a NON-connection (verified live Aug 2026
+ * against a 3rd-degree target that simultaneously offered "Connect"), so
+ * treating that link alone as "already connected" would false-positive exactly
+ * the way the Jul 2026 incident did.
+ */
+export async function assertConnectable(page: Page, topCard: Locator | null, vanity: string | null): Promise<void> {
+  const cardText = topCard ? await topCard.innerText().catch(() => "") : "";
+
+  // 1. Pending first — it must win over weaker signals. Scoped to the target's
+  //    own card: a page-wide [aria-label*="Pending"] also matches sidebar
+  //    modules for other people.
+  if (/\bPending\b/.test(cardText)) throw new PendingInviteError("Invitation already pending");
+  if (topCard && (await topCard.locator(PENDING_IN_CARD).count()) > 0) {
+    throw new PendingInviteError("Invitation already pending");
+  }
+
+  // 2. A Connect affordance on the person's own card is positive proof from
+  //    LinkedIn that they are neither connected nor invited.
+  if (vanity && (await ownConnectLink(page, vanity).count()) > 0) return;
+  if (topCard && (await topCard.locator(CONNECT_CTA).count()) > 0) return;
+
+  // 3. The explicit degree badge is the only card-level connection signal.
   //
-  // MUST be scoped to the visited person's own intro/top card — a page-wide
-  // search also matches "Message" links / "1st" badges belonging to OTHER
-  // people rendered elsewhere on the page (sidebar modules like "People also
-  // viewed"). For a non-connected target this false-positived AlreadyConnected,
-  // which skipped the real invite AND (via the message step that follows) sent
-  // a message to a random unrelated 1st-degree connection instead of the
-  // target — see CLAUDE.md / memory for the Jul 2026 incident. The top card is
-  // identified structurally as the section containing the page's own <h1> name
-  // heading, robust to class-name hashing. Mirrors the same fix in visit.ts.
-  const topCard = page.locator("main section").filter({ has: page.locator("h1") }).first();
-  const hasMessageLink = await topCard.locator('a[href*="/messaging/compose"]').first().count() > 0;
-  if (hasMessageLink) throw new AlreadyConnectedError("Already connected");
-  const pageText = await topCard.innerText().catch(() => "");
-  if (/\b1st\b/.test(pageText)) throw new AlreadyConnectedError("Already connected");
+  //    A Message button / /messaging/compose link — with or without profileUrn —
+  //    is NOT evidence of a connection. Verified live Aug 2026: /in/raise-faster/
+  //    (NOT connected) and /in/demo-investor-4aa78a428/ (confirmed 1st degree)
+  //    both expose `profileUrn=…&screenContext=NON_SELF_PROFILE_VIEW` compose
+  //    links that are structurally identical. Treating that as proof stamped
+  //    degree=1 on a stranger and skipped a real invitation.
+  if (await hasFirstDegreeBadge(topCard)) throw new AlreadyConnectedError("Already connected");
 
-  // Pending?
-  if (/\bPending\b/.test(pageText)) throw new PendingInviteError("Invitation already pending");
-  const pendingBtn = page.locator('button[aria-label*="Pending"]:visible');
-  if (await pendingBtn.count() > 0) throw new PendingInviteError("Invitation already pending");
+  // 4. Otherwise the card is inconclusive (Follow-primary layouts hide Connect
+  //    in the More menu). Return and let openInviteDialog() decide from the
+  //    menu, which carries explicit Connect / Pending / Remove connection items.
+}
 
-  // Case 1: Direct Connect link (primary CTA) — navigate to its href directly.
-  // Clicking fails because the Sales Nav overlay SVG intercepts pointer events.
-  const directConnect = page.locator('a[aria-label*="Invite"][aria-label*="to connect"]:visible, a[href*="custom-invite"]:visible').first();
-  if (await directConnect.count() > 0) {
-    const href = await directConnect.getAttribute("href");
-    if (!href) throw new Error("Connect link has no href");
-    const inviteUrl = href.startsWith("http") ? href : `https://www.linkedin.com${href}`;
-    await page.goto(inviteUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
-    await page.waitForTimeout(1000);
-  } else {
-    // Case 2: Connect is inside the "..." More menu
-    // LinkedIn has two "More" buttons on page: [0] = nav bar, [1] = profile card
-    const moreBtn = page.locator('button[aria-label="More"]:visible').nth(1);
-    await moreBtn.click();
-    await page.waitForTimeout(800);
-
-    // Check for Pending in the menu — means invite was already sent
-    const pendingMenuItem = page.locator('[role="menuitem"]:has-text("Pending"):visible');
-    if (await pendingMenuItem.count() > 0) throw new PendingInviteError("Invitation already pending (found in More menu)");
-
-    const connectOption = page.locator('[role="menuitem"]:has-text("Connect"):visible');
-    if (await connectOption.count() === 0) throw new Error("Connect option not found in More menu");
-    await connectOption.first().click();
-  }
-
-  await page.waitForTimeout(1000);
-
-  // Click "Send without a note" / "Send now"
-  const sendBtn = page.locator(
-    'button:has-text("Send now"), button[aria-label*="Send without"], button[aria-label*="Send invitation"]:not([aria-label*="note"])'
-  );
-  if (await sendBtn.count() > 0) {
-    await sendBtn.first().click({ force: true });
-    await page.waitForTimeout(1500);
-  }
-
-  // Check for weekly limit popup
+/** Weekly-limit popup and LinkedIn error toasts — checked before claiming success. */
+async function assertNoLinkedInError(page: Page): Promise<void> {
   const limitPopup = page.locator('div[class*="ip-fuse-limit-alert__warning"]');
-  if (await limitPopup.count() > 0) throw new WeeklyLimitError("Weekly connection limit reached");
+  if ((await limitPopup.count()) > 0) throw new WeeklyLimitError("Weekly connection limit reached");
 
-  // Check for error toast
   const errorToast = page.locator('div[data-test-artdeco-toast-item-type="error"]:visible');
-  if (await errorToast.count() > 0) {
+  if ((await errorToast.count()) > 0) {
     const msg = await errorToast.innerText();
     throw new Error(`Connection error: ${msg.trim()}`);
   }
+}
+
+/**
+ * Opens the invitation modal and returns its Send button, waiting for it to
+ * actually appear. Throws — never returns a not-found — so a missing button
+ * can't be mistaken for a completed send.
+ */
+export async function openInviteDialog(page: Page, linkedinUrl: string, vanity: string | null): Promise<Locator> {
+  // Case 1: direct Connect link (primary CTA) — navigate to its href.
+  // Clicking it does NOT open the modal: the Sales Nav overlay SVG intercepts
+  // pointer events, and even a forced click is a no-op on this layout
+  // (verified Aug 2026 — force-click succeeded, no dialog appeared). The href
+  // navigation is the working path and is deliberately kept.
+  const directConnect = vanity
+    ? ownConnectLink(page, vanity)
+    : page.locator('a[aria-label*="Invite"][aria-label*="to connect"]:visible, a[href*="custom-invite"]:visible').first();
+
+  if ((await directConnect.count()) > 0) {
+    // Click the real CTA so LinkedIn's own SPA opens the invite modal.
+    //
+    // The click is intercepted unless the CTA is scrolled clear of the sticky
+    // global nav first: Playwright scrolls the element into view, which can
+    // leave it underneath the header, and the hit test then resolves to the
+    // nav's "For Business" button instead (verified live Aug 2026 — the click
+    // times out after 10s of retries, never dispatching). Centring the element
+    // in the viewport moves it out from under the header.
+    await directConnect.evaluate(el => el.scrollIntoView({ block: "center" }));
+    await page.waitForTimeout(300);
+
+    // force: true is what makes the centring stick. Playwright's normal click
+    // re-runs its own scroll-into-view before every retry, which puts the CTA
+    // back under the header and re-fails the hit test — verified Aug 2026: 20
+    // retries, the same "For Business" interception each time. force skips that
+    // retry/hit-test loop and dispatches at the element's own coordinates,
+    // which the centring above has already moved clear of the sticky nav.
+    let modalOpened = false;
+    console.log("[invite-debug] attempting in-page Connect click");
+    try {
+      await directConnect.click({ force: true, timeout: 10000 });
+      await page.locator(INVITE_DIALOG).first().waitFor({ state: "visible", timeout: 10000 });
+      modalOpened = true;
+      console.log("[invite-debug] SPA invite modal opened");
+    } catch (err) {
+      console.log("[invite-debug] in-page Connect click failed");
+      console.log(`[invite-debug] error: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    if (!modalOpened) {
+      // The in-page Connect click is attempted first. If it does not open the
+      // SPA invite dialog, fall back to the target's own
+      // /preload/custom-invite/ URL, taken from the CTA's href.
+      //
+      // Retained as a working compatibility fallback: an invitation sent via
+      // this path was confirmed to become pending by verifyInvitationSent(),
+      // which remains the arbiter either way. (An earlier comment here claimed
+      // this route's Send button was inert and created nothing — that is
+      // contradicted by the verified send and has been removed.)
+      console.log("[invite-debug] falling back to preload invite URL");
+      const href = await directConnect.getAttribute("href");
+      if (!href) throw new InviteUiError("Connect link has no href");
+      await gotoAuthenticated(page, href.startsWith("http") ? href : `https://www.linkedin.com${href}`);
+    }
+  } else {
+    // Case 2: Connect is inside the profile's "…More" menu — the Follow-primary
+    // (creator) layout, where the card offers Follow + Message and no Connect.
+    //
+    // The More button is resolved from the person's OWN top card. The previous
+    // `button[aria-label="More"]:visible'.nth(1)` assumed exactly two on the
+    // page (nav = 0, profile = 1); posts and recommendation cards each add one,
+    // so that index silently opened somebody else's menu.
+    const topCard = await findTopCard(page);
+    const moreBtn = topCard ? topCard.locator(MORE_BUTTON).first() : null;
+    if (!moreBtn || (await moreBtn.count()) === 0) {
+      throw new InviteUiError(
+        `No Connect link and no More button on the profile card at ${page.url()} — cannot open the invitation UI for ${linkedinUrl}`
+      );
+    }
+
+    // Read aria-controls BEFORE clicking: it names the menu this button owns,
+    // which is what lets us scope the item lookup instead of guessing among
+    // whatever menus happen to be open elsewhere on the page.
+    const menuId = await moreBtn.getAttribute("aria-controls").catch(() => null);
+    await moreBtn.click({ timeout: 10000 });
+    await page.waitForTimeout(800);
+
+    const menu = menuId ? page.locator(`#${menuId}`) : page.locator(OPEN_MENU);
+    const menuCount = await menu.count();
+    if (menuCount === 0) {
+      throw new InviteUiError(`The profile More menu did not open at ${page.url()} — invitation not sent`);
+    }
+    if (!menuId && menuCount > 1) {
+      // Several menus are open and the button names none of them; picking one
+      // would be a coin flip, and the wrong pick acts on another person.
+      throw new InviteUiError(
+        `Ambiguous More menu at ${page.url()} (${menuCount} open, no aria-controls) — refusing to guess`
+      );
+    }
+    const openMenu = menu.first();
+
+    const items = openMenu.locator(MENU_ITEM);
+
+    // Pending first.
+    if ((await openMenu.locator(MENU_PENDING_KEY).count()) > 0 ||
+        (await items.filter({ hasText: RE_PENDING }).count()) > 0) {
+      throw new PendingInviteError("Invitation already pending (found in More menu)");
+    }
+
+    // "Remove connection" is offered ONLY for an existing 1st-degree connection,
+    // so its presence is independent evidence of one. It is also the item a
+    // substring match on "Connect" would hit — clicking it would destroy the
+    // relationship. Detect it explicitly, throw, and click nothing.
+    if ((await items.filter({ hasText: RE_REMOVE_CONNECTION }).count()) > 0) {
+      throw new AlreadyConnectedError("Already connected (Remove connection offered in More menu)");
+    }
+
+    // Connect is matched by the invitation href, which names THIS target — a
+    // stranger's Connect item in the same menu carries their vanityName and so
+    // cannot match. Without a vanity there is nothing to bind to, and guessing
+    // is exactly how the wrong person gets invited.
+    if (!vanity) {
+      throw new InviteUiError(`Cannot resolve a target vanity for ${linkedinUrl} — refusing to pick a Connect item`);
+    }
+    const connectOption = openMenu.locator(menuConnectFor(vanity));
+    if ((await connectOption.count()) === 0) {
+      throw new InviteUiError(
+        `The profile More menu offers no Connect action for ${vanity} at ${page.url()} — invitation not sent`
+      );
+    }
+    await connectOption.first().click();
+  }
+
+  // Wait for the Send button instead of sleeping a fixed 1s and hoping. The
+  // fixed wait is what made this fail silently: any slower-than-1s render (or
+  // an auth bounce) left count()===0 and the old code just returned "success".
+  const sendBtn = page.locator(SEND_BUTTON).first();
+  try {
+    await sendBtn.waitFor({ state: "visible", timeout: 20000 });
+  } catch {
+    await assertNoLinkedInError(page);
+
+    // Some invitations require proving you know the person before they can be
+    // sent at all. Report that specifically rather than as a generic timeout.
+    const dialogText = await page.locator(INVITE_DIALOG).first().innerText().catch(() => "");
+    if (/enter their email|to verify this member/i.test(dialogText)) {
+      throw new InviteUiError(
+        `LinkedIn requires an email address to verify you know this person — invitation not sent (${linkedinUrl})`
+      );
+    }
+
+    throw new InviteUiError(
+      `Invitation Send button never appeared at ${page.url()} — invitation NOT sent. ` +
+        `Dialog text: ${dialogText.replace(/\s+/g, " ").trim().slice(0, 200) || "(no dialog)"}`
+    );
+  }
+  return sendBtn;
+}
+
+/**
+ * Confirms LinkedIn actually recorded the invitation. A completed click proves
+ * nothing on its own — this is the only thing that lets the function return
+ * normally.
+ *
+ * Two independent LinkedIn-side signals, cheapest first:
+ *  1. the profile now shows Pending (and no longer offers Connect);
+ *  2. the target appears in the sent-invitations manager.
+ */
+async function verifyInvitationSent(page: Page, linkedinUrl: string, vanity: string | null): Promise<void> {
+  await gotoAuthenticated(page, linkedinUrl);
+  await page.waitForTimeout(2500);
+
+  const topCard = await findTopCard(page);
+  const cardText = topCard ? await topCard.innerText().catch(() => "") : "";
+  const pendingBadge = await page
+    .locator('button[aria-label*="Pending"]:visible, [aria-label*="Pending"]:visible')
+    .count();
+  const connectStillOffered = vanity ? await ownConnectLink(page, vanity).count() : 0;
+
+  if ((pendingBadge > 0 || /\bPending\b/.test(cardText)) && connectStillOffered === 0) return;
+
+  // Authoritative second opinion — the same scrape the daily accepted-sync uses.
+  if (vanity) {
+    const pending = await scrapePendingInvitationVanityNames(page).catch(() => null);
+    if (pending?.has(vanity)) return;
+    if (pending) {
+      throw new InviteNotSentError(
+        `Invitation to ${linkedinUrl} is not pending on LinkedIn after clicking Send ` +
+          `(profile shows no Pending state and ${vanity} is absent from the sent-invitations list) — treating as NOT sent`
+      );
+    }
+  }
+
+  throw new InviteNotSentError(
+    `Could not confirm the invitation to ${linkedinUrl} was sent ` +
+      `(no Pending state on the profile${connectStillOffered > 0 ? ", Connect is still offered" : ""}) — treating as NOT sent`
+  );
+}
+
+/**
+ * Sends a LinkedIn connection request without a note, and returns only once
+ * LinkedIn confirms the invitation is pending.
+ *
+ * Throws WeeklyLimitError if the weekly limit popup appears, AlreadyConnected/
+ * PendingInviteError if already in that state, SessionExpiredError if the
+ * session is dead, InviteUiError if the invitation UI can't be completed, and
+ * InviteNotSentError if the send can't be confirmed afterwards. It never
+ * returns normally without positive confirmation — the runner records
+ * connection_requested_at on return, so a silent no-op here is recorded as a
+ * real invitation and the contact is never retried.
+ */
+export async function sendConnectionRequest(page: Page, linkedinUrl: string): Promise<void> {
+  const vanity = vanityNameOf(linkedinUrl);
+
+  await gotoAuthenticated(page, linkedinUrl);
+  await page.waitForTimeout(2000 + Math.random() * 1000);
+
+  const topCard = await findTopCard(page);
+  await assertConnectable(page, topCard, vanity);
+
+  const sendBtn = await openInviteDialog(page, linkedinUrl, vanity);
+  await sendBtn.click();
+  await page.waitForTimeout(2500);
+
+  await assertNoLinkedInError(page);
+  await verifyInvitationSent(page, linkedinUrl, vanity);
 }

--- a/lib/linkedin/message.ts
+++ b/lib/linkedin/message.ts
@@ -2,6 +2,8 @@ import type { Page } from "playwright";
 import { visitProfile } from "./visit";
 
 export class NotConnectedError extends Error {}
+/** Connected, but no messaging URN resolved — never guess the recipient by name. */
+export class MessagingUrnUnresolvedError extends Error {}
 
 export interface SendMessageResult {
   messagingUrn: string | null;
@@ -35,30 +37,34 @@ export async function sendMessage(
   linkedinUrl: string,
   messagingUrn?: string | null
 ): Promise<SendMessageResult> {
-  if (messagingUrn) {
-    const opened = await openComposeByUrn(page, messagingUrn);
-    if (opened) {
-      await sendFromComposeBox(page, text);
-      return { messagingUrn, isFirstDegree: true };
-    }
-  }
-
+  // The live visit is the ONLY authorization. A cached URN used to short-circuit
+  // this entirely — openComposeByUrn() ran first and the profile was never
+  // checked — so a DB degree=1 that had gone stale (or was written from a UI
+  // misread) sent a message to a non-connection with no verification at all.
+  // A URN is an address, never permission.
   const resolved = await visitProfile(page, linkedinUrl);
-  if (resolved.messagingUrn) {
-    const opened = await openComposeByUrn(page, resolved.messagingUrn);
-    if (opened) {
-      await sendFromComposeBox(page, text);
-      return resolved;
-    }
-  }
+
   if (!resolved.isFirstDegree) {
+    // Runner self-healing depends on this: it resets degree/connected_at to NULL.
     throw new NotConnectedError(`${fullName} is not a 1st-degree connection — refusing to message`);
   }
 
-  // Connected, but no message link could be resolved live (unusual layout) —
-  // last-resort fallback to name search.
-  await sendMessageViaTypeahead(page, fullName, text);
-  return resolved;
+  // Connected. Prefer the URN just read from the live profile; fall back to the
+  // cached one only as an address for a confirmed connection.
+  const urn = resolved.messagingUrn ?? messagingUrn ?? null;
+  if (urn && (await openComposeByUrn(page, urn))) {
+    await sendFromComposeBox(page, text);
+    return { messagingUrn: urn, isFirstDegree: true };
+  }
+
+  // Connected, but no messaging URN could be resolved. The old code fell back to
+  // searching LinkedIn's connections typeahead by display name, which is how an
+  // unrelated person with a similar/truncated name got messaged (Jul 2026), and
+  // which in Aug 2026 searched the literal vanity slug "raise-faster". A name is
+  // not an identity: fail with a dedicated error instead of guessing a recipient.
+  throw new MessagingUrnUnresolvedError(
+    `${fullName} appears connected but no messaging URN could be resolved from ${linkedinUrl} — refusing to pick a recipient by name`
+  );
 }
 
 async function openComposeByUrn(page: Page, messagingUrn: string): Promise<boolean> {
@@ -75,45 +81,11 @@ async function openComposeByUrn(page: Page, messagingUrn: string): Promise<boole
   }
 }
 
-async function sendMessageViaTypeahead(page: Page, fullName: string, text: string): Promise<void> {
-  await page.goto("https://www.linkedin.com/messaging/thread/new/", {
-    waitUntil: "domcontentloaded",
-    timeout: 30000,
-  });
-  await page.waitForTimeout(1500 + Math.random() * 1000);
-
-  // Search for recipient by name
-  const searchField = page.locator("input.msg-connections-typeahead__search-field").first();
-  await searchField.waitFor({ timeout: 10000 });
-  await searchField.click();
-  await searchField.type(fullName, { delay: 60 + Math.random() * 40 });
-  await page.waitForTimeout(1500);
-
-  // Select first result — but verify it's actually the intended person first.
-  // This search only returns 1st-degree connections; if the real target isn't
-  // connected, LinkedIn will still happily return a same/similar-named
-  // connection as the top result, and we'd silently message a stranger.
-  const firstResult = page.locator('div[class*="msg-connections-typeahead__search-result-row"]').first();
-  await firstResult.waitFor({ timeout: 8000 });
-  const resultText = (await firstResult.innerText().catch(() => "")).trim();
-  if (!resultNameMatches(resultText, fullName)) {
-    throw new Error(
-      `Typeahead search for "${fullName}" returned a non-matching result ("${resultText.replace(/\s+/g, " ")}") — refusing to send to avoid messaging the wrong person`
-    );
-  }
-  await firstResult.click({ delay: 100 });
-  await page.waitForTimeout(800);
-
-  await sendFromComposeBox(page, text);
-}
-
-function resultNameMatches(resultText: string, fullName: string): boolean {
-  const normalize = (s: string) =>
-    s.toLowerCase().normalize("NFKD").replace(/[̀-ͯ]/g, "").replace(/[^a-z\s]/g, " ").replace(/\s+/g, " ").trim();
-  const target = normalize(fullName);
-  if (!target) return false;
-  return normalize(resultText).includes(target);
-}
+// The name-search typeahead that used to live here has been REMOVED, not just
+// bypassed. It selected a recipient by display name, which messaged an
+// unrelated person in Jul 2026 and, in Aug 2026, searched the literal vanity
+// slug "raise-faster". Messaging now requires a resolved URN; there is no
+// name-based path to fall back into, by construction.
 
 async function sendFromComposeBox(page: Page, text: string): Promise<void> {
   // Paste message into compose area

--- a/lib/linkedin/runner.ts
+++ b/lib/linkedin/runner.ts
@@ -1,7 +1,7 @@
 import { getDb } from "@/lib/db";
 import { randomUUID } from "crypto";
 import { getSessionPage, saveSessionState, getSessionContext } from "@/lib/linkedin/session";
-import { visitProfile } from "@/lib/linkedin/visit";
+import { visitProfile, type VisitResult } from "@/lib/linkedin/visit";
 import { sendConnectionRequest, WeeklyLimitError, AlreadyConnectedError, PendingInviteError } from "@/lib/linkedin/connect";
 import { sendMessage, NotConnectedError } from "@/lib/linkedin/message";
 import { shouldSyncAccepted, syncAcceptedConnections } from "@/lib/linkedin/sync-accepted";
@@ -37,6 +37,11 @@ const PROFILE_DELAY_MIN = 8;
 const PROFILE_DELAY_MAX = 20;
 // Poll interval (ms)
 const POLL_INTERVAL_MS = 30_000;
+// How far ahead a claimed track's next_step_at is pushed while it executes.
+// Long enough to cover the slowest real step (Playwright invite sends have been
+// observed around 45s), short enough that a track orphaned by a crashed process
+// comes back on its own without manual intervention.
+const CLAIM_LEASE_MINUTES = 15;
 
 interface ScheduleConfig {
   active_hours_start: number;
@@ -85,13 +90,77 @@ function isWithinSchedule(account: ScheduleConfig): boolean {
   return frac >= (account.active_hours_start ?? 9) && frac < (account.active_hours_end ?? 18);
 }
 
+function zonedDateTimeToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  timezone: string,
+): Date {
+  let guess = new Date(Date.UTC(year, month - 1, day, hour, minute, 0));
+
+  for (let i = 0; i < 3; i++) {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).formatToParts(guess);
+
+    const get = (type: string) =>
+      parts.find(p => p.type === type)?.value ?? "0";
+
+    const localAsUtc = Date.UTC(
+      parseInt(get("year"), 10),
+      parseInt(get("month"), 10) - 1,
+      parseInt(get("day"), 10),
+      parseInt(get("hour"), 10) % 24,
+      parseInt(get("minute"), 10),
+      parseInt(get("second"), 10),
+    );
+
+    const offset = localAsUtc - guess.getTime();
+    guess = new Date(
+      Date.UTC(year, month - 1, day, hour, minute, 0) - offset
+    );
+  }
+
+  return guess;
+}
+
 function randomSlotInActiveWindow(account: ScheduleConfig, targetDate?: Date): string {
   const start = account.active_hours_start ?? 9;
   const end = account.active_hours_end ?? 18;
+  const timezone = account.timezone || "UTC";
   const base = targetDate ? new Date(targetDate) : new Date();
-  const startMs = new Date(base.getFullYear(), base.getMonth(), base.getDate(), start, 0, 0).getTime();
-  const endMs   = new Date(base.getFullYear(), base.getMonth(), base.getDate(), end,   0, 0).getTime();
-  return new Date(startMs + Math.random() * (endMs - startMs)).toISOString();
+
+  const dateParts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+  }).formatToParts(base);
+
+  const get = (type: string) =>
+    dateParts.find(p => p.type === type)?.value ?? "0";
+
+  const year = parseInt(get("year"), 10);
+  const month = parseInt(get("month"), 10);
+  const day = parseInt(get("day"), 10);
+
+  const startUtc = zonedDateTimeToUtc(year, month, day, start, 0, timezone);
+  const endUtc = zonedDateTimeToUtc(year, month, day, end, 0, timezone);
+
+  const slot =
+    startUtc.getTime() +
+    Math.random() * (endUtc.getTime() - startUtc.getTime());
+
+  return new Date(slot).toISOString();
 }
 
 function rescheduleToTomorrow(account: ScheduleConfig): string {
@@ -231,6 +300,34 @@ function trAdvance(db: ReturnType<typeof getDb>, tr: TrackRun, steps: WorkflowSt
 
 function trWait(db: ReturnType<typeof getDb>, tr: TrackRun, hours: number) {
   db.prepare("UPDATE run_profile_tracks SET next_step_at = ? WHERE id = ?").run(addHours(hours), tr.id);
+}
+
+/**
+ * Atomically claim a due track before executing it. Returns false if the claim
+ * was lost, in which case the caller must skip the track entirely.
+ *
+ * The due-query and the execution used to be separate statements, so a track
+ * stayed `in_progress` with `next_step_at` in the past for the whole step —
+ * ~45s for a Playwright invite. Anything else reading the DB in that window
+ * (a second runner process or container, or this process restarting mid-step)
+ * saw the same row as due and ran it again, sending a duplicate invite.
+ *
+ * The WHERE clause re-asserts the exact predicate the due-query used, so the
+ * check and the claim are one statement and SQLite settles the race: exactly
+ * one caller sees changes === 1. The new next_step_at is only a lease — every
+ * terminal path in executeStep (trAdvance/trWait/trReschedule/trSkip/trFail)
+ * overwrites it, so normal scheduling is unaffected. If the process dies first,
+ * the lease expires and the track becomes due again on its own.
+ */
+export function trClaim(db: ReturnType<typeof getDb>, trackId: string): boolean {
+  // ISO-UTC via toISOString(), matching every other next_step_at write here.
+  const leaseUntil = new Date(Date.now() + CLAIM_LEASE_MINUTES * 60_000).toISOString();
+  const claimed = db.prepare(
+    `UPDATE run_profile_tracks SET next_step_at = ?
+     WHERE id = ? AND state = 'in_progress'
+       AND (next_step_at IS NULL OR datetime(next_step_at) <= datetime('now'))`
+  ).run(leaseUntil, trackId);
+  return claimed.changes === 1;
 }
 
 function trReschedule(db: ReturnType<typeof getDb>, tr: TrackRun, isoTimestamp: string) {
@@ -458,7 +555,9 @@ async function ensureApolloEnriched(db: ReturnType<typeof getDb>, target: Target
 
 // ─── step execution ──────────────────────────────────────────────────────────
 
-async function executeStep(
+// Exported for tests: lets the connect step's error handling be driven with
+// the LinkedIn modules mocked out, without standing up a whole tick.
+export async function executeStep(
   db: ReturnType<typeof getDb>,
   runId: string,
   tr: TrackRun,
@@ -502,13 +601,24 @@ async function executeStep(
       log(db, runId, target.id, "info", `Visiting ${name}`);
       const linkedinUrl = await getLinkedinUrl(db, target, accountId);
       const page = await getSessionPage(accountId);
-      let visitResult: { isFirstDegree: boolean; messagingUrn: string | null };
+      let visitResult: VisitResult;
       try { visitResult = await visitProfile(page, linkedinUrl); } finally { await page.close(); }
       await saveSessionState(accountId);
-      if (visitResult.isFirstDegree && target.degree !== 1) {
+      if (visitResult.degree === "first_degree" && target.degree !== 1) {
         db.prepare("UPDATE targets SET degree = 1, connected_at = COALESCE(connected_at, ?) WHERE id = ?").run(nowIso(), target.id);
         log(db, runId, target.id, "info", `${name} already 1st-degree — backfilled connection status`);
+      } else if (visitResult.degree === "not_first_degree" && target.degree === 1) {
+        // Self-heal a stale degree=1, mirroring the message step's reset at the
+        // NotConnectedError path. Gated on the POSITIVE observation, never on
+        // !isFirstDegree: "inconclusive" means the card was never inspected, so
+        // clearing on it would erase a correct connection whenever the page was
+        // slow, the layout drifted, or LinkedIn served an auth wall.
+        db.prepare("UPDATE targets SET degree = NULL, connected_at = NULL WHERE id = ?").run(target.id);
+        log(db, runId, target.id, "warn", `${name} no longer appears 1st-degree — resetting connection status`);
       }
+      // messaging_urn is intentionally left alone on a reset: it is an address,
+      // not authorization, and message.ts re-verifies the degree live before it
+      // is ever used to address anything.
       if (visitResult.messagingUrn) {
         db.prepare("UPDATE targets SET messaging_urn = COALESCE(messaging_urn, ?) WHERE id = ?").run(visitResult.messagingUrn, target.id);
       }
@@ -915,8 +1025,17 @@ async function executeStep(
       return;
     }
     if (err instanceof PendingInviteError) {
+      // LinkedIn already holds the invite, so the send must NOT be retried —
+      // this is the recovery path for a process that died between the invite
+      // landing and connection_requested_at being written. Recording it here
+      // makes the retry a no-op instead of a duplicate invite.
       log(db, runId, target.id, "info", `${name} invite already pending — will recheck`);
-      if (!target.connection_requested_at) db.prepare("UPDATE targets SET connection_requested_at = ? WHERE id = ?").run(nowIso(), target.id);
+      // COALESCE rather than a JS null-check on `target`: that row was read
+      // before the send, so the column may have been written since. Stamping
+      // in SQL keeps the original request time instead of overwriting it.
+      db.prepare(
+        "UPDATE targets SET connection_requested_at = COALESCE(connection_requested_at, ?) WHERE id = ?"
+      ).run(nowIso(), target.id);
       trWait(db, tr, CONNECTION_RECHECK_HOURS);
       return;
     }
@@ -1372,28 +1491,63 @@ async function tick(db: ReturnType<typeof getDb>): Promise<void> {
     const runStatus = db.prepare("SELECT status FROM runs WHERE id = ?").get(tr.run_id) as { status: string } | undefined;
     if (!runStatus || runStatus.status !== "running") continue;
 
+    // Claim it before any work happens — another runner may have taken this
+    // same row out of its own due-query since ours ran.
+    if (!trClaim(db, tr.id)) continue;
+
     const target = db.prepare("SELECT * FROM targets WHERE id = ?").get(tr.target_id) as Target;
     await executeStep(db, tr.run_id, tr, target, steps, tr.account_id, limits, emailAccountId, emailLimits, getWorkflowPrompt(tr.workflow_id));
     await randomDelay(PROFILE_DELAY_MIN, PROFILE_DELAY_MAX);
   }
 }
 
-function spreadEnrollBatch(
+export function spreadEnrollBatch(
   db: ReturnType<typeof getDb>,
   runId: string,
   pending: Array<{ id: string; run_profile_id: string; track: string }>,
   limits: ScheduleConfig,
-  track: string
+  track: string,
+  /** Injected only by tests, so slots are assertable without the real clock. */
+  opts: { now?: Date; random?: () => number } = {}
 ) {
   const batchSize = pending.length;
   if (batchSize === 0) return;
+  const now = opts.now ?? new Date();
+  const rand = opts.random ?? Math.random;
+  const tz = limits.timezone || "UTC";
   const start = limits.active_hours_start ?? 9;
   const end = limits.active_hours_end ?? 18;
-  const { hour, minute } = getLocalParts(limits.timezone || "UTC");
+  const { hour, minute } = getLocalParts(tz, now);
   const nowFrac = hour + minute / 60;
-  const windowMs = (end - start) * 3600_000;
-  const bucketMs = windowMs / batchSize;
-  const dayStartMs = new Date().setHours(start, 0, 0, 0);
+  const dateParts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+  }).formatToParts(now);
+
+  const getDatePart = (type: string) =>
+    dateParts.find(p => p.type === type)?.value ?? "0";
+
+  const year = parseInt(getDatePart("year"), 10);
+  const month = parseInt(getDatePart("month"), 10);
+  const day = parseInt(getDatePart("day"), 10);
+  const dayStartMs = zonedDateTimeToUtc(year, month, day, start, 0, tz).getTime();
+  const dayEndMs = zonedDateTimeToUtc(year, month, day, end, 0, tz).getTime();
+
+  // Buckets are laid out from whichever is LATER: the window's start, or now.
+  //
+  // Anchoring them to today's active_hours_start meant a batch enrolled partway
+  // through the window drew slots that had already passed, so every such contact
+  // became due on the very next tick — precisely the burst the spreading exists
+  // to prevent (verified Aug 2026: enrolled 14:06:38 into a 09:00-18:00 window,
+  // executed 14:07:08). Re-basing divides the time that is actually LEFT in the
+  // day among the batch, so slots are always >= now and still spread out.
+  //
+  // Enrolling before the window opens is unaffected: dayStartMs wins, and the
+  // distribution is identical to before.
+  const spreadStartMs = Math.max(dayStartMs, now.getTime());
+  const bucketMs = Math.max(0, dayEndMs - spreadStartMs) / batchSize;
 
   for (let i = 0; i < pending.length; i++) {
     const row = pending[i];
@@ -1403,9 +1557,8 @@ function spreadEnrollBatch(
     if (claimed.changes === 0) continue;
     const slot = (() => {
       if (nowFrac >= end - 0.25) return rescheduleToTomorrow(limits);
-      const bucketStart = dayStartMs + i * bucketMs;
-      const bucketEnd = bucketStart + bucketMs;
-      return new Date(bucketStart + Math.random() * (bucketEnd - bucketStart)).toISOString();
+      const bucketStart = spreadStartMs + i * bucketMs;
+      return new Date(bucketStart + rand() * bucketMs).toISOString();
     })();
     db.prepare("UPDATE run_profile_tracks SET next_step_at = ? WHERE id = ?").run(slot, row.id);
     const tgt = db.prepare("SELECT full_name, linkedin_url FROM targets WHERE id = (SELECT target_id FROM run_profiles WHERE id = ?)").get(row.run_profile_id) as { full_name: string | null; linkedin_url: string } | undefined;

--- a/lib/linkedin/session.test.ts
+++ b/lib/linkedin/session.test.ts
@@ -1,0 +1,206 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// session.ts opens the SQLite DB and encrypts with NEXTAUTH_SECRET at call
+// time, so point both at throwaway values BEFORE the module is loaded.
+const dbDir = mkdtempSync(join(tmpdir(), "linki-session-test-"));
+process.env.LINKI_DB_PATH = join(dbDir, "test.db");
+process.env.NEXTAUTH_SECRET ??= "test-secret-for-session-guard-tests";
+
+const {
+  findAuthCookie,
+  isAuthenticatedStorageState,
+  isLoggedInAppUrl,
+  persistAuthenticatedState,
+  refreshStoredSessionState,
+  AuthenticationNotEstablishedError,
+} = await import("./session");
+const { getDb } = await import("@/lib/db");
+
+// lib/db.ts caches one connection for the process and never closes it (correct
+// for a long-lived server, but it leaves the WAL/SHM files and this temp dir
+// behind after every test run). Close it here — test-side only — so SQLite
+// checkpoints and releases the files before we delete the directory.
+after(() => {
+  try { getDb().close(); } catch { /* never opened, or already closed */ }
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+// Cookie sets taken from real observed states. The "authwall" set is the exact
+// cookie list found on the account that was stored as is_authenticated = 1 with
+// no session at all (Aug 2026 phantom-auth incident).
+
+const cookie = (name: string, value = "v", domain = ".linkedin.com") => ({
+  name,
+  value,
+  domain,
+  path: "/",
+});
+
+const state = (...names: string[]) => ({ cookies: names.map(n => cookie(n)), origins: [] });
+
+/** A genuine post-login state. */
+const AUTHENTICATED = {
+  cookies: [
+    cookie("li_at", "AQEDATEsomeRealLookingSessionToken"),
+    cookie("JSESSIONID", '"ajax:1234"'),
+    cookie("bcookie"),
+    cookie("lidc"),
+  ],
+  origins: [],
+};
+
+/** The observed authwall state: tracking + remember-me, but no session. */
+const AUTHWALL = state(
+  "JSESSIONID", "PLAY_LANG", "__cf_bm", "bcookie", "bscookie", "fid", "lang",
+  "li_rm", "li_theme", "li_theme_set", "lidc", "rtc", "sdui_ver", "timezone",
+  "trkCode", "trkInfo"
+);
+
+let accountSeq = 0;
+function makeAccount(): string {
+  const id = `acct-${++accountSeq}`;
+  getDb()
+    .prepare("INSERT INTO accounts (id, name, email, is_authenticated) VALUES (?, ?, ?, 0)")
+    .run(id, `Test ${id}`, `${id}@example.com`);
+  return id;
+}
+
+const flagOf = (id: string) =>
+  (getDb().prepare("SELECT is_authenticated FROM accounts WHERE id = ?").get(id) as
+    { is_authenticated: number }).is_authenticated;
+
+const storedCookiesOf = (id: string) =>
+  (getDb().prepare("SELECT cookies_json FROM accounts WHERE id = ?").get(id) as
+    { cookies_json: string | null }).cookies_json;
+
+// ─── (a) li_at present → authenticated ───────────────────────────────────────
+
+test("storage state containing li_at is authenticated", () => {
+  assert.equal(isAuthenticatedStorageState(AUTHENTICATED), true);
+  assert.equal(findAuthCookie(AUTHENTICATED)?.value, "AQEDATEsomeRealLookingSessionToken");
+});
+
+test("persistAuthenticatedState marks the account authenticated when li_at is present", () => {
+  const id = makeAccount();
+  persistAuthenticatedState(id, AUTHENTICATED, "test");
+  assert.equal(flagOf(id), 1);
+  assert.notEqual(storedCookiesOf(id), null, "the state should be persisted");
+});
+
+// ─── (b) no li_at → not authenticated ────────────────────────────────────────
+
+test("storage state without li_at is not authenticated", () => {
+  assert.equal(isAuthenticatedStorageState(state("JSESSIONID", "bcookie", "lidc")), false);
+  assert.equal(isAuthenticatedStorageState({ cookies: [], origins: [] }), false);
+  assert.equal(isAuthenticatedStorageState(undefined), false);
+});
+
+test("persistAuthenticatedState refuses to write the flag when li_at is missing", () => {
+  const id = makeAccount();
+  assert.throws(
+    () => persistAuthenticatedState(id, state("JSESSIONID", "bcookie"), "test"),
+    AuthenticationNotEstablishedError
+  );
+  assert.equal(flagOf(id), 0, "must not be marked authenticated");
+  assert.equal(storedCookiesOf(id), null, "must not persist the state as a successful login");
+});
+
+test("an empty or whitespace-only li_at is not a session", () => {
+  assert.equal(isAuthenticatedStorageState({ cookies: [cookie("li_at", "")] }), false);
+  assert.equal(isAuthenticatedStorageState({ cookies: [cookie("li_at", "   ")] }), false);
+});
+
+test("an li_at scoped to a non-LinkedIn domain is not a session", () => {
+  assert.equal(
+    isAuthenticatedStorageState({
+      cookies: [cookie("li_at", "tok", ".evil.example")],
+    }),
+    false
+  );
+});
+
+// ─── (c) li_rm without li_at → not authenticated ─────────────────────────────
+
+test("li_rm without li_at is not authentication", () => {
+  // li_rm is the remember-me cookie: LinkedIn sets it on a browser that has
+  // NOT completed sign-in, so on its own it proves nothing.
+  const s = state("li_rm", "bcookie", "lidc");
+  assert.equal(isAuthenticatedStorageState(s), false);
+  assert.equal(findAuthCookie(s), null);
+});
+
+// ─── (d) authwall / tracking cookies without li_at → not authenticated ───────
+
+test("the observed authwall cookie set is not authentication", () => {
+  assert.equal(isAuthenticatedStorageState(AUTHWALL), false);
+});
+
+test("trkCode/trkInfo authwall tracking cookies are not authentication", () => {
+  assert.equal(isAuthenticatedStorageState(state("trkCode", "trkInfo")), false);
+});
+
+test("the exact phantom-auth state can never be stored as authenticated", () => {
+  // End-to-end regression guard for the incident: this is the state that was
+  // found in the DB alongside is_authenticated = 1.
+  const id = makeAccount();
+  assert.throws(
+    () => persistAuthenticatedState(id, AUTHWALL, "test"),
+    (e: unknown) =>
+      e instanceof AuthenticationNotEstablishedError &&
+      /li_at/.test(e.message) &&
+      e.cookieNames.includes("trkInfo")
+  );
+  assert.equal(flagOf(id), 0);
+});
+
+// ─── saveSessionState's mid-run branch ───────────────────────────────────────
+
+test("a mid-run session refresh clears the flag instead of throwing when li_at is gone", () => {
+  // The runner calls this immediately before recording a sent invite/message,
+  // so it must not throw — but it also must not leave is_authenticated = 1.
+  const id = makeAccount();
+  persistAuthenticatedState(id, AUTHENTICATED, "test");
+  assert.equal(flagOf(id), 1);
+
+  const before = storedCookiesOf(id);
+  assert.equal(refreshStoredSessionState(id, AUTHWALL), "cleared");
+  assert.equal(flagOf(id), 0, "a dead session must clear the flag");
+  assert.equal(storedCookiesOf(id), before, "the authwall state must not overwrite the stored one");
+});
+
+test("a mid-run session refresh saves a still-valid session", () => {
+  const id = makeAccount();
+  assert.equal(refreshStoredSessionState(id, AUTHENTICATED), "saved");
+  assert.equal(flagOf(id), 1);
+});
+
+// ─── URL classification ──────────────────────────────────────────────────────
+
+test("an authwall URL is not a logged-in URL even when it embeds /sales/ or /feed/", () => {
+  // The regression that let an authwall classify as authenticated: the
+  // destination is echoed back inside the authwall's own query string.
+  assert.equal(
+    isLoggedInAppUrl(
+      "https://www.linkedin.com/authwall?trk=bf&original_referer=https://www.linkedin.com/sales/&sessionRedirect=https%3A%2F%2Fwww.linkedin.com%2Ffeed%2F"
+    ),
+    false
+  );
+  assert.equal(isLoggedInAppUrl("https://www.linkedin.com/login?session_redirect=/feed/"), false);
+  assert.equal(isLoggedInAppUrl("https://www.linkedin.com/checkpoint/challenge/"), false);
+});
+
+test("real logged-in URLs still classify as logged in", () => {
+  assert.equal(isLoggedInAppUrl("https://www.linkedin.com/feed/"), true);
+  assert.equal(isLoggedInAppUrl("https://www.linkedin.com/sales/home"), true);
+  assert.equal(isLoggedInAppUrl("https://www.linkedin.com/sales/"), true);
+});
+
+test("non-LinkedIn hosts never classify as logged in", () => {
+  assert.equal(isLoggedInAppUrl("https://linkedin.com.evil.example/feed/"), false);
+  assert.equal(isLoggedInAppUrl("not a url"), false);
+});

--- a/lib/linkedin/session.ts
+++ b/lib/linkedin/session.ts
@@ -160,15 +160,129 @@ export async function getSessionPage(accountId: string): Promise<Page> {
   return page;
 }
 
+// ─── Authentication guard ─────────────────────────────────────────────────────
+// B7 (Aug 2026 phantom-auth incident): an account was found with
+// is_authenticated = 1 while its persisted storage state contained NO li_at —
+// LinkedIn served /authwall for every navigation, yet the runner kept picking
+// the account up because it only ever consulted the DB flag. The saved state
+// held li_rm, trkCode and trkInfo: the cookies LinkedIn hands a LOGGED-OUT
+// visitor sitting on an authwall. Any one of them can be present on a session
+// that has never authenticated, so none of them is evidence of anything.
+//
+// li_at is the only cookie that constitutes a LinkedIn session. The rule is
+// therefore: is_authenticated = 1 is written ONLY together with a storage
+// state that carries a non-empty li_at. Every write path goes through the
+// helpers below so the flag cannot drift from the browser state again.
+
+/** Shape of the subset of Playwright's storageState() this module reasons about. */
+export type SessionStorageState = {
+  cookies?: { name: string; value: string; domain?: string }[];
+  origins?: unknown[];
+};
+
+/** Raised when a login flow finishes without LinkedIn having issued a session. */
+export class AuthenticationNotEstablishedError extends Error {
+  readonly cookieNames: string[];
+  constructor(accountId: string, cookieNames: string[]) {
+    super(
+      `LinkedIn authentication was not established for account ${accountId}: ` +
+        `the session cookie (li_at) is absent from the browser state. ` +
+        `Cookies present: ${cookieNames.length ? cookieNames.join(", ") : "(none)"}. ` +
+        `This is a logged-out/authwall session — the account has NOT been marked authenticated.`
+    );
+    this.name = "AuthenticationNotEstablishedError";
+    this.cookieNames = cookieNames;
+  }
+}
+
+/**
+ * The single source of truth for "is this browser state actually logged in?".
+ * Returns the li_at cookie, or null. Deliberately narrow: only li_at counts,
+ * it must carry a non-empty value, and (when the state records a domain) it
+ * must belong to LinkedIn.
+ */
+export function findAuthCookie(
+  state: SessionStorageState | null | undefined
+): { name: string; value: string } | null {
+  const cookies = state?.cookies;
+  if (!Array.isArray(cookies)) return null;
+  for (const c of cookies) {
+    if (!c || c.name !== "li_at") continue;
+    if (typeof c.value !== "string" || c.value.trim() === "") continue;
+    if (typeof c.domain === "string" && c.domain !== "" && !c.domain.includes("linkedin.com")) continue;
+    return { name: c.name, value: c.value };
+  }
+  return null;
+}
+
+/** True only when `state` proves an established LinkedIn session. */
+export function isAuthenticatedStorageState(state: SessionStorageState | null | undefined): boolean {
+  return findAuthCookie(state) !== null;
+}
+
+function cookieNamesOf(state: SessionStorageState | null | undefined): string[] {
+  return Array.isArray(state?.cookies) ? state!.cookies!.map(c => c?.name).filter(Boolean) : [];
+}
+
+/**
+ * Persist a storage state as an authenticated session. Writes
+ * is_authenticated = 1 if and only if li_at is present; otherwise writes
+ * nothing and throws, so no caller can report a login as successful.
+ */
+export function persistAuthenticatedState(
+  accountId: string,
+  state: SessionStorageState,
+  source: string
+): void {
+  if (!isAuthenticatedStorageState(state)) {
+    const names = cookieNamesOf(state);
+    console.error(
+      `[auth] ${source}: REFUSING to mark account ${accountId} authenticated — no li_at in the ` +
+        `browser state (LinkedIn session was never established). Cookies present: ` +
+        `${names.length ? names.join(", ") : "(none)"}. Cookies such as li_rm/trkCode/trkInfo are ` +
+        `served to logged-out visitors and are not proof of authentication.`
+    );
+    throw new AuthenticationNotEstablishedError(accountId, names);
+  }
+  getDb()
+    .prepare("UPDATE accounts SET cookies_json = ?, is_authenticated = 1 WHERE id = ?")
+    .run(encryptSecret(JSON.stringify(state)), accountId);
+}
+
+/**
+ * Refresh the stored cookies for a live session (called by the runner after
+ * each action to keep rotating cookies fresh).
+ *
+ * Non-throwing by contract: the runner calls this immediately BEFORE recording
+ * a sent invite/message, so raising here would lose the record of an action
+ * LinkedIn has already performed. When the session has died mid-run we
+ * therefore clear is_authenticated rather than throw — the account stops being
+ * picked up, and the existing SessionExpiredError path handles the in-flight
+ * work. The one thing that never happens is writing is_authenticated = 1 for a
+ * state with no li_at.
+ */
+export function refreshStoredSessionState(
+  accountId: string,
+  state: SessionStorageState
+): "saved" | "cleared" {
+  if (!isAuthenticatedStorageState(state)) {
+    const names = cookieNamesOf(state);
+    console.error(
+      `[auth] saveSessionState: account ${accountId} lost its LinkedIn session — li_at is gone ` +
+        `from the live browser context (cookies present: ${names.length ? names.join(", ") : "(none)"}). ` +
+        `Clearing is_authenticated and keeping the previous stored state; re-authentication is required.`
+    );
+    getDb().prepare("UPDATE accounts SET is_authenticated = 0 WHERE id = ?").run(accountId);
+    return "cleared";
+  }
+  persistAuthenticatedState(accountId, state, "saveSessionState");
+  return "saved";
+}
+
 export async function saveSessionState(accountId: string): Promise<void> {
   const ctx = contexts.get(accountId);
   if (!ctx) return;
-  const db = getDb();
-  const state = await ctx.storageState();
-  db.prepare("UPDATE accounts SET cookies_json = ?, is_authenticated = 1 WHERE id = ?").run(
-    encryptSecret(JSON.stringify(state)),
-    accountId
-  );
+  refreshStoredSessionState(accountId, (await ctx.storageState()) as SessionStorageState);
 }
 
 export async function closeSession(accountId: string): Promise<void> {
@@ -241,14 +355,14 @@ export async function authenticateAccount(accountId: string): Promise<void> {
     // Wait up to 3 minutes for the user to complete login and reach /feed
     await page.waitForURL("**/feed/**", { timeout: 180_000 });
 
-    // Save full storage state (cookies + localStorage) to DB
-    const state = await ctx.storageState();
-    db.prepare("UPDATE accounts SET cookies_json = ?, is_authenticated = 1 WHERE id = ?").run(
-      encryptSecret(JSON.stringify(state)),
-      accountId
-    );
-
-    await ctx.close();
+    // Save full storage state (cookies + localStorage) to DB. Guarded: reaching
+    // /feed is not by itself proof of a session — only li_at is.
+    const state = (await ctx.storageState()) as SessionStorageState;
+    try {
+      persistAuthenticatedState(accountId, state, "authenticateAccount");
+    } finally {
+      await ctx.close();
+    }
   } finally {
     await visibleBrowser.close();
   }
@@ -304,6 +418,12 @@ function sweepPendingLogins(): void {
  * calling storageState(), capturing the FULL session the runner needs.
  * Best-effort: if the account has no Sales Nav seat the nav simply doesn't add
  * the seat cookie — the rest of the (regular-LinkedIn) session is still saved.
+ *
+ * The Sales Nav navigation stays best-effort, but its failure is now LOGGED
+ * rather than silently dropped, and — critically — it can no longer produce a
+ * false "authenticated": if that navigation lands on an authwall (i.e. the
+ * login never really took), the li_at check below refuses the write and throws.
+ * Callers surface that as a login error.
  */
 async function persistLogin(accountId: string, ctx: BrowserContext, page?: Page): Promise<void> {
   if (page) {
@@ -311,16 +431,16 @@ async function persistLogin(accountId: string, ctx: BrowserContext, page?: Page)
       await page.goto("https://www.linkedin.com/sales/home", { waitUntil: "domcontentloaded", timeout: 30_000 });
       // Let Sales Nav's bootstrap requests fire so li_ep_auth_context is set.
       await page.waitForTimeout(4_000);
-    } catch {
-      // Non-fatal — a missing seat / slow load must not fail the whole login.
+    } catch (e) {
+      // Non-fatal for the seat cookie — a missing seat / slow load must not fail
+      // the login on its own. Authentication itself is decided by li_at below.
+      console.warn(`[login] account ${accountId}: Sales Nav warm-up failed (${(e as Error).message}) — continuing`);
     }
   }
-  const db = getDb();
-  const state = await ctx.storageState();
-  db.prepare("UPDATE accounts SET cookies_json = ?, is_authenticated = 1 WHERE id = ?").run(
-    encryptSecret(JSON.stringify(state)),
-    accountId
-  );
+  const state = (await ctx.storageState()) as SessionStorageState;
+  // Throws AuthenticationNotEstablishedError (and writes nothing) when li_at is
+  // absent — the guard that stops an authwall session being stored as valid.
+  persistAuthenticatedState(accountId, state, "persistLogin");
   // Drop any stale runtime context so the runner reloads the fresh cookies.
   await closeSession(accountId);
 }
@@ -331,12 +451,38 @@ async function persistLogin(accountId: string, ctx: BrowserContext, page?: Page)
  * approval — so we detect both: a visible code input = otp; a checkpoint page
  * with no code input and no captcha = device approval.
  */
+/**
+ * Does this URL look like a landed-on-the-logged-in-app URL?
+ *
+ * Matched against the PATHNAME only. An authwall URL carries the original
+ * destination in its query string
+ * (`/authwall?...&sessionRedirect=https://www.linkedin.com/sales/`), so the
+ * older whole-URL regexes could see "/sales/" inside a logged-OUT page's query
+ * and classify an authwall as authenticated. /authwall, /login and /checkpoint
+ * are rejected outright.
+ *
+ * This is only a cheap first gate: authentication is decided by li_at in
+ * persistAuthenticatedState(), never by the URL alone.
+ */
+export function isLoggedInAppUrl(rawUrl: string): boolean {
+  let path: string;
+  try {
+    const u = new URL(rawUrl);
+    if (!/(^|\.)linkedin\.com$/.test(u.hostname)) return false;
+    path = u.pathname;
+  } catch {
+    return false;
+  }
+  if (/^\/(authwall|login|uas\/login|checkpoint)(\/|$)/.test(path)) return false;
+  return /^\/feed(\/|$)/.test(path) || /^\/sales(\/|$)/.test(path);
+}
+
 async function classifyLoginState(page: Page): Promise<LoginResult> {
   const start = Date.now();
   const deadline = start + 20_000;
   while (Date.now() < deadline) {
     const url = page.url();
-    if (/\/feed\//.test(url) || /linkedin\.com\/sales\//.test(url)) {
+    if (isLoggedInAppUrl(url)) {
       return { status: "authenticated" };
     }
 

--- a/lib/linkedin/visit.ts
+++ b/lib/linkedin/visit.ts
@@ -1,4 +1,5 @@
 import type { Page } from "playwright";
+import { findTopCard, hasFirstDegreeBadge } from "./connect";
 
 /**
  * Visits a LinkedIn profile page. This registers as a profile view on LinkedIn.
@@ -6,10 +7,10 @@ import type { Page } from "playwright";
  * lets the runner backfill degree=1 for contacts that were already connected
  * before Linki ever sent them a connection request (e.g. manually added leads).
  *
- * Primary-degree signal: presence of the profile's primary "Message" link
- * (a[href*="/messaging/compose"]) — only shown to 1st-degree connections, reads
- * an href attribute rather than a CSS class or translated text, so it survives
- * both LinkedIn's periodic class-name hashing and non-English UI languages.
+ * Degree signal: the visible 1st-degree badge on the person's own card, via
+ * connect.ts's hasFirstDegreeBadge(). The Message link is NOT a degree signal —
+ * a confirmed non-connection and a confirmed 1st-degree connection both render
+ * /messaging/compose links carrying profileUrn (verified live Aug 2026).
  *
  * MUST be scoped to the visited person's own intro/top card — a page-wide
  * search also matches "Message" links belonging to OTHER people rendered
@@ -19,30 +20,101 @@ import type { Page } from "playwright";
  * unrelated 1st-degree connection's link, wrongly marked the target degree=1,
  * and stored that stranger's messaging URN, causing messages to go to the
  * wrong person entirely (incident: Jul 2026, see CLAUDE.md/memory). The top
- * card is identified structurally as the section containing the page's own
- * <h1> name heading, which is robust to LinkedIn's class-name hashing.
+ * card is resolved by connect.ts's findTopCard(), which identifies it
+ * structurally on both the current SDUI and legacy layouts and is robust to
+ * LinkedIn's class-name hashing.
  *
- * Falls back to the old text-scrape (/\b1st\b/ within that same top card)
- * when the link isn't found, in case the current account's profile layout
- * doesn't render it as a plain link (e.g. buried behind a click/menu).
- *
- * The same link's href carries the messaging URN (urn:li:fsd_profile:ACoAA...)
- * needed to message this person directly later without a name-search typeahead
- * — see lib/linkedin/message.ts. Returned as messagingUrn when found.
+ * The Message link's href carries the messaging URN (urn:li:fsd_profile:ACoAA...)
+ * used to address a message. It answers "who do we send to?", never "are we
+ * connected?" — so it is returned only once the badge has established the
+ * connection. See lib/linkedin/message.ts.
  */
-export async function visitProfile(page: Page, linkedinUrl: string): Promise<{ isFirstDegree: boolean; messagingUrn: string | null }> {
+/**
+ * What the visit actually established about the connection.
+ *
+ * The two negative states are NOT interchangeable, which is the whole reason
+ * this type exists. A plain `isFirstDegree: false` conflated "we looked and
+ * they are not connected" with "we could not look at all" — so the visit step
+ * could neither trust nor clear a stored degree=1 without risking erasing a
+ * correct one on a transient render failure or an auth wall.
+ *
+ *  - "first_degree"     — the person's own card shows the visible 1st badge.
+ *  - "not_first_degree" — the card WAS inspected and shows no such badge.
+ *  - "inconclusive"     — the card could not be found, so nothing was observed.
+ *                         Absence of evidence, never evidence of absence: only
+ *                         "not_first_degree" may clear a stored degree.
+ */
+export type DegreeObservation = "first_degree" | "not_first_degree" | "inconclusive";
+
+export interface VisitResult {
+  degree: DegreeObservation;
+  /**
+   * Kept so every existing caller — message.ts above all — keeps working
+   * unchanged, and keeps failing CLOSED: it is true ONLY for "first_degree",
+   * so both negative states still refuse to authorize a message.
+   */
+  isFirstDegree: boolean;
+  messagingUrn: string | null;
+}
+
+export async function visitProfile(page: Page, linkedinUrl: string): Promise<VisitResult> {
   await page.goto(linkedinUrl, { waitUntil: "domcontentloaded", timeout: 30000 });
   await page.waitForTimeout(3000 + Math.random() * 2000);
 
-  const topCard = page.locator("main section").filter({ has: page.locator("h1") }).first();
+  // Shared with connect.ts rather than re-declared: the <h1>-anchored locator
+  // this used to inline matches NOTHING on LinkedIn's current SDUI layout,
+  // where the name is an <h2> and the card is keyed by componentkey. That made
+  // every check below degrade silently to "not connected" — a connected target
+  // was reported as 1st-degree=false, which surfaced as a false NotConnectedError
+  // in sendMessage() (verified live Aug 2026). findTopCard() handles both
+  // layouts, so the two modules can no longer drift apart.
+  const topCard = await findTopCard(page);
+  // No card = nothing was inspected. Report it as such rather than as a
+  // negative: the card can be missing because the page is still rendering,
+  // because LinkedIn shipped a third layout, because the profile 404'd, or
+  // because we were served a login/authwall page (see the note at the bottom
+  // of this file). None of those are "not connected".
+  if (!topCard) return { degree: "inconclusive", isFirstDegree: false, messagingUrn: null };
 
   const messageLink = topCard.locator('a[href*="/messaging/compose"]').first();
   const messageHref = (await messageLink.count()) > 0 ? await messageLink.getAttribute("href").catch(() => null) : null;
   const urnMatch = messageHref?.match(/profileUrn=([^&]+)/);
-  const messagingUrn = urnMatch ? decodeURIComponent(urnMatch[1]) : null;
+  const composeUrn = urnMatch ? decodeURIComponent(urnMatch[1]) : null;
 
-  if (messageHref) return { isFirstDegree: true, messagingUrn };
+  // Connection status comes from the explicit degree badge on the person's own
+  // card — NEVER from the Message button or its href.
+  //
+  // Verified live Aug 2026: /in/raise-faster/ (NOT connected) and
+  // /in/demo-investor-4aa78a428/ (confirmed 1st degree) both render
+  // `/messaging/compose/?profileUrn=…&screenContext=NON_SELF_PROFILE_VIEW`.
+  // The links are structurally identical, so neither the link nor profileUrn
+  // can distinguish them. Reading the link as proof marked a stranger
+  // 1st-degree, which stamped degree=1 and skipped a real invitation.
+  // Same contract as connect.ts: a visible, element-level degree badge — never
+  // the card's prose, which routinely contains "1st" for unrelated reasons.
+  //
+  // A rejection here (detached DOM, closed page) propagates deliberately. The
+  // card was found but could not be read, so the observation is unknown — and
+  // an exception reaches the runner's catch-all, which fails the track without
+  // ever writing a degree. Swallowing it into "not_first_degree" would let a
+  // torn-down page erase a correct connection.
+  const isFirstDegree = await hasFirstDegreeBadge(topCard);
 
-  const pageText = await topCard.innerText().catch(() => "");
-  return { isFirstDegree: /\b1st\b/.test(pageText), messagingUrn: null };
+  // The URN is only meaningful once the connection itself is established; it is
+  // the addressing handle for messaging, not evidence of the relationship.
+  return {
+    degree: isFirstDegree ? "first_degree" : "not_first_degree",
+    isFirstDegree,
+    messagingUrn: isFirstDegree ? composeUrn : null,
+  };
 }
+
+// KNOWN GAP, deliberately not fixed here (reported separately): the goto above
+// is a raw page.goto, while every LinkedIn navigation in connect.ts goes through
+// gotoAuthenticated(), which polls the login interstitial and raises
+// SessionExpiredError on an authwall. So an expired session renders a wall, no
+// top card is found, and this returns "inconclusive" — safe by construction
+// now, where the old boolean reported a confident "not first degree". Routing
+// this through gotoAuthenticated() would turn that case into an explicit error
+// instead, which is strictly better but is a navigation change, not part of the
+// three-state result.

--- a/lib/update-check.ts
+++ b/lib/update-check.ts
@@ -5,6 +5,10 @@
  * State is kept in memory (reset on restart, which is fine — it re-checks immediately).
  */
 
+// Imported explicitly rather than taken from the global: tsconfig pulls in the
+// "dom" lib, whose setInterval returns a number with no unref().
+import { setInterval } from "node:timers";
+
 const DOCKER_HUB_TAGS_URL =
   "https://hub.docker.com/v2/repositories/moaljumaa/linki/tags?page_size=50&ordering=last_updated";
 
@@ -83,6 +87,9 @@ export function scheduleUpdateCheck() {
   // Run immediately on startup (non-blocking)
   checkForUpdate();
 
-  // Then every 12 hours
-  setInterval(checkForUpdate, POLL_INTERVAL_MS);
+  // Then every 12 hours. unref'd so a background version poll can never be the
+  // reason the process stays alive — without it, anything that touches getDb()
+  // (which schedules this) inherits a 12-hour handle and never exits. That is
+  // what wedged `npm test`: the suite passed, then sat on this timer.
+  setInterval(checkForUpdate, POLL_INTERVAL_MS).unref();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -94,7 +94,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1831,7 +1830,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1897,7 +1895,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -2477,7 +2474,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2993,7 +2989,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3941,7 +3936,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4127,7 +4121,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4421,7 +4414,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5125,7 +5117,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
       "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7882,7 +7873,6 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
       "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -8328,7 +8318,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.2"
       },
@@ -8359,7 +8348,6 @@
       "resolved": "https://registry.npmjs.org/playwright-extra/-/playwright-extra-4.3.6.tgz",
       "integrity": "sha512-q2rVtcE8V8K3vPVF1zny4pvwZveHLH8KBuVU2MoE3Jw4OKVoBWsHI9CH9zPydovHHOCDxjGN2Vg+2m644q3ijA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -8423,7 +8411,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.4.tgz",
       "integrity": "sha512-uKFfOHWuSNpRFVTnljsCluEFq57OKT+0QdOiQo8XWnQ/pSvg7OpX5eNOejELXJMWy+BwM2nobz0FkvzmnpCNsQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -8780,7 +8767,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8790,7 +8776,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9904,7 +9889,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10148,7 +10132,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10618,7 +10601,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "retest:connect": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --import ./scripts/test-setup.mjs scripts/retest-connect.ts",
+    "test": "node --experimental-strip-types --experimental-test-module-mocks --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --disable-warning=ExperimentalWarning --import ./scripts/test-setup.mjs --test \"lib/**/*.test.ts\" \"tests/**/*.test.ts\"",
     "mirror:ee": "node scripts/mirror-ee.js"
   },
   "dependencies": {

--- a/pages/api/accounts/[id]/authenticate.ts
+++ b/pages/api/accounts/[id]/authenticate.ts
@@ -1,6 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getDb } from "@/lib/db";
-import { encryptSecret } from "@/lib/crypto";
+import {
+  persistAuthenticatedState,
+  AuthenticationNotEstablishedError,
+} from "@/lib/linkedin/session";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") return res.status(405).end();
@@ -37,10 +40,16 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     origins: [],
   };
 
-  db.prepare("UPDATE accounts SET cookies_json = ?, is_authenticated = 1 WHERE id = ?").run(
-    encryptSecret(JSON.stringify(storageState)),
-    id
-  );
+  // Same guard as the login flows: the flag is only ever written alongside a
+  // state carrying a non-empty li_at (a whitespace-only paste reaches here).
+  try {
+    persistAuthenticatedState(id, storageState, "cookie-paste");
+  } catch (e) {
+    if (e instanceof AuthenticationNotEstablishedError) {
+      return res.status(400).json({ error: "A valid li_at cookie is required" });
+    }
+    throw e;
+  }
 
   // Evict the cached browser context so next import uses the new cookies
   const { closeSession } = await import("@/lib/linkedin/session");

--- a/pages/api/accounts/[id]/index.ts
+++ b/pages/api/accounts/[id]/index.ts
@@ -37,8 +37,22 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   if (req.method === "DELETE") {
-    db.prepare("DELETE FROM accounts WHERE id = ?").run(id);
-    return res.status(204).end();
+    try {
+      const { changes } = db.prepare("DELETE FROM accounts WHERE id = ?").run(id);
+      if (changes === 0) return res.status(404).json({ error: "Not found" });
+      return res.status(204).end();
+    } catch (err) {
+      // runs.account_id references accounts(id) with no ON DELETE clause, so
+      // SQLite refuses to orphan an account's runs. Report that as a conflict
+      // the caller can act on instead of a 500 the UI can't explain.
+      if ((err as { code?: string }).code === "SQLITE_CONSTRAINT_FOREIGNKEY") {
+        return res.status(409).json({
+          error:
+            "This account still has runs attached. Stop and delete those runs first, then delete the account.",
+        });
+      }
+      throw err;
+    }
   }
 
   res.setHeader("Allow", ["GET", "PUT", "DELETE"]);

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -346,7 +346,15 @@ function LinkedInTab({ initialAccounts }: { initialAccounts: LiAccount[] }) {
 
   async function deleteAccount(id: string) {
     if (!confirm("Delete this LinkedIn account?")) return;
-    await fetch(`/api/accounts/${id}`, { method: "DELETE" });
+    const res = await fetch(`/api/accounts/${id}`, { method: "DELETE" });
+    if (!res.ok) {
+      // A failed DELETE must not be reported as success: the row is still in
+      // the DB, so dropping it from local state only hides it until a refresh.
+      // 500s render as HTML, so don't assume the body parses as JSON.
+      const error = await res.json().catch(() => null);
+      toast.error(error?.error ?? "Failed to delete account");
+      return;
+    }
     toast.success("Deleted");
     setAccounts((prev) => prev.filter((a) => a.id !== id));
   }

--- a/scripts/retest-connect.ts
+++ b/scripts/retest-connect.ts
@@ -1,0 +1,75 @@
+/**
+ * Live retest harness for the LinkedIn connection-request flow.
+ *
+ * Runs the REAL production code from lib/linkedin/connect.ts against a real
+ * authenticated session, so a pass here means the shipped selectors work — not
+ * a copy of them.
+ *
+ * Preflight (default) is read-only: it navigates, resolves the top card, runs
+ * the already-connected/pending guards and opens the invitation modal, then
+ * reports whether the Send button is actually there — and exits WITHOUT
+ * clicking it. Nothing is sent.
+ *
+ * With --send it calls sendConnectionRequest() end to end, which really does
+ * send an invitation to a real person.
+ *
+ *   npm run retest:connect -- <accountId> <profileUrl>
+ *   npm run retest:connect -- <accountId> <profileUrl> --send
+ */
+import { getSessionPage, saveSessionState } from "@/lib/linkedin/session";
+import {
+  sendConnectionRequest,
+  findTopCard,
+  assertConnectable,
+  openInviteDialog,
+  vanityNameOf,
+  gotoAuthenticated,
+} from "@/lib/linkedin/connect";
+
+const [accountId, profileUrl] = process.argv.slice(2).filter(a => !a.startsWith("--"));
+const doSend = process.argv.includes("--send");
+
+if (!accountId || !profileUrl) {
+  console.error("usage: npm run retest:connect -- <accountId> <profileUrl> [--send]");
+  process.exit(2);
+}
+
+(async () => {
+  const page = await getSessionPage(accountId);
+  try {
+    if (doSend) {
+      console.log(`[retest] SENDING a real invitation to ${profileUrl}`);
+      await sendConnectionRequest(page, profileUrl);
+      console.log("[retest] PASS — sendConnectionRequest returned, so LinkedIn confirmed the invite is pending");
+      return;
+    }
+
+    console.log(`[retest] preflight (read-only, nothing will be sent) for ${profileUrl}`);
+    const vanity = vanityNameOf(profileUrl);
+    console.log("  vanityName:", vanity);
+
+    await gotoAuthenticated(page, profileUrl);
+    await page.waitForTimeout(4000);
+    console.log("  landed on:", page.url());
+
+    const topCard = await findTopCard(page);
+    console.log("  top card found:", topCard !== null);
+    if (topCard) {
+      console.log("  top card text:", (await topCard.innerText().catch(() => "")).replace(/\s+/g, " ").slice(0, 160));
+    }
+
+    await assertConnectable(page, topCard, vanity);
+    console.log("  connectable: yes (not already connected, no pending invite)");
+
+    const sendBtn = await openInviteDialog(page, profileUrl, vanity);
+    console.log("  invite page:", page.url());
+    console.log("  Send button aria-label:", await sendBtn.getAttribute("aria-label"));
+    console.log("[retest] PASS — invitation modal reached and the Send button is present. Not clicking it.");
+  } finally {
+    await page.close();
+    await saveSessionState(accountId).catch(() => {});
+  }
+})().catch(err => {
+  console.error(`[retest] FAIL — ${err?.constructor?.name}: ${err?.message}`);
+  process.exit(1);
+});

--- a/scripts/test-resolve-hooks.mjs
+++ b/scripts/test-resolve-hooks.mjs
@@ -1,0 +1,33 @@
+// Resolve hooks for `node --test`.
+//
+// The app's source is bundler-resolved (Next), so it imports siblings
+// extensionless (`./pending-invitations`) and uses the `@/*` path alias. Node's
+// ESM resolver does neither. These hooks bridge the gap so test files can load
+// the real modules unchanged, with no build step and no extra dependency.
+import { pathToFileURL } from "node:url";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = resolvePath(dirname(fileURLToPath(import.meta.url)), "..");
+
+export async function resolve(specifier, context, nextResolve) {
+  let spec = specifier;
+
+  if (spec.startsWith("@/")) {
+    spec = pathToFileURL(resolvePath(projectRoot, spec.slice(2))).href;
+  }
+
+  try {
+    return await nextResolve(spec, context);
+  } catch (err) {
+    if (err?.code !== "ERR_MODULE_NOT_FOUND" || /\.[cm]?[jt]sx?$/.test(spec)) throw err;
+    for (const ext of [".ts", ".tsx", "/index.ts"]) {
+      try {
+        return await nextResolve(spec + ext, context);
+      } catch {
+        // try the next candidate extension
+      }
+    }
+    throw err;
+  }
+}

--- a/scripts/test-setup.mjs
+++ b/scripts/test-setup.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register("./test-resolve-hooks.mjs", import.meta.url);

--- a/tests/accounts-api.test.ts
+++ b/tests/accounts-api.test.ts
@@ -1,0 +1,120 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// lib/db.ts resolves the DB path at first getDb() call, so point it at a
+// throwaway file BEFORE the module is loaded.
+const dbDir = mkdtempSync(join(tmpdir(), "linki-accounts-api-test-"));
+process.env.LINKI_DB_PATH = join(dbDir, "test.db");
+process.env.NEXTAUTH_SECRET ??= "test-secret-for-accounts-api-tests";
+
+// Lives here rather than beside the route: Next treats every file under
+// pages/api as an API route, so a co-located *.test.ts fails `next build`.
+const { default: handler } = await import("@/pages/api/accounts/[id]/index");
+const { getDb } = await import("@/lib/db");
+
+after(() => {
+  try { getDb().close(); } catch { /* never opened, or already closed */ }
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+// ─── harness ─────────────────────────────────────────────────────────────────
+
+interface Captured {
+  statusCode: number;
+  body: unknown;
+  ended: boolean;
+}
+
+/** Minimal NextApiResponse capturing what the handler sends back. */
+function mockRes(): { res: NextApiResponse; captured: Captured } {
+  const captured: Captured = { statusCode: 200, body: undefined, ended: false };
+  const res = {
+    status(code: number) { captured.statusCode = code; return this; },
+    json(body: unknown) { captured.body = body; return this; },
+    end() { captured.ended = true; return this; },
+    setHeader() { return this; },
+  };
+  return { res: res as unknown as NextApiResponse, captured };
+}
+
+function del(id: string): Captured {
+  const req = { method: "DELETE", query: { id }, body: {} } as unknown as NextApiRequest;
+  const { res, captured } = mockRes();
+  handler(req, res);
+  return captured;
+}
+
+let seq = 0;
+function makeAccount(): string {
+  const id = `acct-${++seq}`;
+  getDb()
+    .prepare("INSERT INTO accounts (id, name, email) VALUES (?, ?, ?)")
+    .run(id, `Test ${id}`, `${id}@example.com`);
+  return id;
+}
+
+function attachRun(accountId: string, status = "running"): string {
+  const id = `run-${accountId}`;
+  getDb()
+    .prepare("INSERT INTO runs (id, account_id, status) VALUES (?, ?, ?)")
+    .run(id, accountId, status);
+  return id;
+}
+
+const accountExists = (id: string) =>
+  getDb().prepare("SELECT 1 FROM accounts WHERE id = ?").get(id) !== undefined;
+
+// ─── DELETE ──────────────────────────────────────────────────────────────────
+
+test("DELETE removes an account with no runs and returns 204", () => {
+  const id = makeAccount();
+  const r = del(id);
+  assert.equal(r.statusCode, 204);
+  assert.equal(r.ended, true);
+  assert.equal(accountExists(id), false, "the row should actually be gone");
+});
+
+test("DELETE returns 404 when the account does not exist", () => {
+  const r = del("no-such-account");
+  assert.equal(r.statusCode, 404);
+  assert.deepEqual(r.body, { error: "Not found" });
+});
+
+test("DELETE returns 409 instead of throwing when the account still has runs", () => {
+  // runs.account_id references accounts(id) with no ON DELETE clause, so SQLite
+  // refuses the delete. The regression this guards: the raw SqliteError escaped
+  // the handler as a 500, the UI ignored it and reported success, and the
+  // account reappeared on refresh.
+  const id = makeAccount();
+  attachRun(id);
+
+  const r = del(id);
+
+  assert.equal(r.statusCode, 409);
+  assert.match((r.body as { error: string }).error, /runs/i);
+  assert.equal(accountExists(id), true, "the account must survive a refused delete");
+});
+
+test("an account becomes deletable once its runs are gone", () => {
+  const id = makeAccount();
+  const runId = attachRun(id);
+  assert.equal(del(id).statusCode, 409);
+
+  getDb().prepare("DELETE FROM runs WHERE id = ?").run(runId);
+
+  assert.equal(del(id).statusCode, 204);
+  assert.equal(accountExists(id), false);
+});
+
+test("a refused delete leaves other accounts untouched", () => {
+  const blocked = makeAccount();
+  const bystander = makeAccount();
+  attachRun(blocked);
+
+  assert.equal(del(blocked).statusCode, 409);
+  assert.equal(accountExists(bystander), true);
+});

--- a/tests/enroll-scheduling.test.ts
+++ b/tests/enroll-scheduling.test.ts
@@ -1,0 +1,223 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dbDir = mkdtempSync(join(tmpdir(), "linki-enroll-sched-test-"));
+process.env.LINKI_DB_PATH = join(dbDir, "test.db");
+process.env.NEXTAUTH_SECRET ??= "test-secret-for-enroll-scheduling-tests";
+
+const { spreadEnrollBatch } = await import("@/lib/linkedin/runner");
+const { getDb } = await import("@/lib/db");
+
+after(() => {
+  try { getDb().close(); } catch { /* already closed */ }
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const LIMITS = { active_hours_start: 9, active_hours_end: 18, timezone: "UTC", working_days: "1,2,3,4,5,6,7" };
+
+let seq = 0;
+let lastRunId = "";
+/** N pending tracks under one run. Returns their ids in order. */
+function makeBatch(n: number): Array<{ id: string; run_profile_id: string; track: string }> {
+  const runId = `run-${++seq}`;
+  lastRunId = runId;
+  const db = getDb();
+  db.prepare("INSERT INTO runs (id, status) VALUES (?, 'running')").run(runId);
+  const rows: Array<{ id: string; run_profile_id: string; track: string }> = [];
+  for (let i = 0; i < n; i++) {
+    const profileId = `prof-${seq}-${i}`;
+    const trackId = `trk-${seq}-${i}`;
+    db.prepare("INSERT INTO run_profiles (id, run_id) VALUES (?, ?)").run(profileId, runId);
+    db.prepare(
+      `INSERT INTO run_profile_tracks (id, run_profile_id, track, state, current_step, next_step_at)
+       VALUES (?, ?, 'linkedin', 'pending', 0, NULL)`
+    ).run(trackId, profileId);
+    rows.push({ id: trackId, run_profile_id: profileId, track: "linkedin" });
+  }
+  return rows;
+}
+
+const slotsOf = (rows: Array<{ id: string }>): number[] =>
+  rows.map(r => {
+    const v = (getDb().prepare("SELECT next_step_at FROM run_profile_tracks WHERE id = ?").get(r.id) as
+      { next_step_at: string | null }).next_step_at;
+    assert.ok(v, `track ${r.id} must have been scheduled`);
+    return new Date(v).getTime();
+  });
+
+const stateOf = (id: string) =>
+  (getDb().prepare("SELECT state FROM run_profile_tracks WHERE id = ?").get(id) as { state: string }).state;
+
+/** Deterministic "random": always mid-bucket. */
+const midBucket = () => 0.5;
+const at = (iso: string) => new Date(iso);
+const HOUR = 3600_000;
+
+// A fixed Saturday, so weekday handling can't vary run to run.
+const WINDOW_START = at("2026-08-08T09:00:00.000Z");
+const WINDOW_END = at("2026-08-08T18:00:00.000Z");
+
+// ─── (1) before the window → existing behaviour preserved ────────────────────
+
+test("enrolling before the window spreads across the whole window, as before", () => {
+  const rows = makeBatch(3);
+  const now = at("2026-08-08T07:00:00.000Z"); // 2h before open
+
+  spreadEnrollBatch(getDb(), lastRunId, rows, LIMITS, "linkedin", { now, random: midBucket });
+
+  const slots = slotsOf(rows);
+  // buckets of 3h across 09:00-18:00, sampled mid-bucket → 10:30, 13:30, 16:30
+  assert.deepEqual(slots.map(s => new Date(s).toISOString()), [
+    "2026-08-08T10:30:00.000Z",
+    "2026-08-08T13:30:00.000Z",
+    "2026-08-08T16:30:00.000Z",
+  ]);
+  assert.ok(slots[0] >= WINDOW_START.getTime(), "must not precede the window");
+});
+
+// ─── (2) exactly at window start ─────────────────────────────────────────────
+
+test("enrolling exactly at the window start behaves identically to enrolling before it", () => {
+  const rows = makeBatch(3);
+
+  spreadEnrollBatch(getDb(), lastRunId, rows, LIMITS, "linkedin", { now: WINDOW_START, random: midBucket });
+
+  assert.deepEqual(slotsOf(rows).map(s => new Date(s).toISOString()), [
+    "2026-08-08T10:30:00.000Z",
+    "2026-08-08T13:30:00.000Z",
+    "2026-08-08T16:30:00.000Z",
+  ]);
+});
+
+// ─── (3) halfway through the window → every slot >= now ──────────────────────
+
+test("enrolling halfway through the window schedules every slot at or after now", () => {
+  // This is the regression: anchored at 09:00, buckets 0-1 landed in the past.
+  const rows = makeBatch(6);
+  const now = at("2026-08-08T13:30:00.000Z");
+
+  spreadEnrollBatch(getDb(), lastRunId, rows, LIMITS, "linkedin", { now, random: midBucket });
+
+  const slots = slotsOf(rows);
+  for (const [i, s] of slots.entries()) {
+    assert.ok(s >= now.getTime(), `slot ${i} (${new Date(s).toISOString()}) must not be in the past`);
+    assert.ok(s <= WINDOW_END.getTime(), `slot ${i} must stay inside the window`);
+  }
+});
+
+// ─── (4) late in the window → spread across what remains ─────────────────────
+
+test("enrolling late spreads the batch across the remaining interval, not all at now", () => {
+  const rows = makeBatch(4);
+  const now = at("2026-08-08T16:00:00.000Z"); // 2h left
+
+  spreadEnrollBatch(getDb(), lastRunId, rows, LIMITS, "linkedin", { now, random: midBucket });
+
+  const slots = slotsOf(rows);
+  // 2h / 4 = 30min buckets, mid-bucket → 16:15, 16:45, 17:15, 17:45
+  assert.deepEqual(slots.map(s => new Date(s).toISOString()), [
+    "2026-08-08T16:15:00.000Z",
+    "2026-08-08T16:45:00.000Z",
+    "2026-08-08T17:15:00.000Z",
+    "2026-08-08T17:45:00.000Z",
+  ]);
+  // strictly increasing, i.e. genuinely spread rather than clamped together
+  for (let i = 1; i < slots.length; i++) {
+    assert.ok(slots[i] > slots[i - 1], "slots must remain strictly ordered");
+  }
+});
+
+// ─── (5) single-item batch ───────────────────────────────────────────────────
+
+test("a single-item batch enrolled mid-window is never scheduled in the past", () => {
+  // The exact live failure: one contact, enrolled 14:06 into a 09:00-18:00
+  // window, drew a slot from 09:00 and became due on the next tick.
+  const now = at("2026-08-08T14:06:00.000Z");
+
+  for (const r of [0, 0.5, 0.999]) {
+    const rows = makeBatch(1);
+    spreadEnrollBatch(getDb(), lastRunId, rows, LIMITS, "linkedin", { now, random: () => r });
+    const [slot] = slotsOf(rows);
+    assert.ok(slot >= now.getTime(), `random=${r} produced a past slot ${new Date(slot).toISOString()}`);
+    assert.ok(slot <= WINDOW_END.getTime());
+  }
+});
+
+// ─── (6) multi-item batch → no burst ─────────────────────────────────────────
+
+test("a multi-item batch enrolled mid-window produces no burst of immediately-due slots", () => {
+  const rows = makeBatch(10);
+  const now = at("2026-08-08T14:00:00.000Z");
+
+  spreadEnrollBatch(getDb(), lastRunId, rows, LIMITS, "linkedin", { now, random: () => 0 }); // worst case: bucket floor
+
+  const slots = slotsOf(rows);
+  const dueImmediately = slots.filter(s => s <= now.getTime() + 1000).length;
+  assert.equal(dueImmediately, 1, "at most the first slot may be at now; the rest must be spread");
+  // 4h remaining / 10 = 24min apart
+  assert.equal(slots[1] - slots[0], 24 * 60_000);
+  assert.equal(slots[9] - slots[0], 9 * 24 * 60_000);
+});
+
+// ─── (7) at/near window end → tomorrow behaviour preserved ───────────────────
+
+test("enrolling within the last 15 minutes still reschedules to tomorrow", () => {
+  // rescheduleToTomorrow() reads the real clock, so anchor `now` to it and
+  // shape the window around it instead of asserting a fixed timestamp.
+  const realNow = new Date();
+  const hourUtc = realNow.getUTCHours() + realNow.getUTCMinutes() / 60;
+  const limits = { ...LIMITS, active_hours_start: 0, active_hours_end: Math.min(24, hourUtc + 0.1) };
+
+  const rows = makeBatch(2);
+  spreadEnrollBatch(getDb(), lastRunId, rows, limits, "linkedin", { now: realNow, random: midBucket });
+
+  for (const s of slotsOf(rows)) {
+    assert.ok(s > realNow.getTime(), "the tomorrow slot must be in the future");
+    assert.ok(s > realNow.getTime() + 6 * HOUR, "must land on a later day, not the tail of today");
+  }
+});
+
+// ─── (8) timezone boundaries ─────────────────────────────────────────────────
+
+test("the window is computed in the account timezone, not UTC", () => {
+  const limits = { ...LIMITS, timezone: "Asia/Kolkata" }; // UTC+5:30
+  const rows = makeBatch(2);
+  // 05:00Z = 10:30 IST — inside a 09:00-18:00 IST window, 7.5h remaining.
+  const now = at("2026-08-08T05:00:00.000Z");
+
+  spreadEnrollBatch(getDb(), lastRunId, rows, limits, "linkedin", { now, random: midBucket });
+
+  const slots = slotsOf(rows);
+  const windowEndUtc = at("2026-08-08T12:30:00.000Z").getTime(); // 18:00 IST
+  for (const s of slots) {
+    assert.ok(s >= now.getTime(), "slot must not precede now");
+    assert.ok(s <= windowEndUtc, "slot must stay inside the IST window");
+  }
+  // 7.5h / 2 = 3.75h buckets, mid-bucket → 06:52:30Z and 10:37:30Z
+  assert.deepEqual(slots.map(s => new Date(s).toISOString()), [
+    "2026-08-08T06:52:30.000Z",
+    "2026-08-08T10:37:30.000Z",
+  ]);
+});
+
+// ─── (9) already-enrolled tracks are untouched ───────────────────────────────
+
+test("tracks that are no longer pending keep their existing next_step_at", () => {
+  const rows = makeBatch(2);
+  const existing = "2026-08-08T17:00:00.000Z";
+  // Simulate the first row already claimed+scheduled by another pass.
+  getDb().prepare("UPDATE run_profile_tracks SET state='in_progress', next_step_at=? WHERE id=?")
+    .run(existing, rows[0].id);
+
+  spreadEnrollBatch(getDb(), lastRunId, rows, LIMITS, "linkedin", { now: at("2026-08-08T13:00:00.000Z"), random: midBucket });
+
+  const untouched = (getDb().prepare("SELECT next_step_at FROM run_profile_tracks WHERE id = ?").get(rows[0].id) as
+    { next_step_at: string }).next_step_at;
+  assert.equal(untouched, existing, "an already-claimed track must not be rescheduled");
+  assert.equal(stateOf(rows[1].id), "in_progress", "the still-pending track is claimed normally");
+});

--- a/tests/first-degree-detection.test.ts
+++ b/tests/first-degree-detection.test.ts
@@ -1,0 +1,256 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Page, Locator } from "playwright";
+
+const { assertConnectable, findTopCard, AlreadyConnectedError, PendingInviteError } =
+  await import("@/lib/linkedin/connect");
+const { visitProfile } = await import("@/lib/linkedin/visit");
+const { sendMessage, NotConnectedError } = await import("@/lib/linkedin/message");
+
+const URL = "https://www.linkedin.com/in/raise-faster/";
+const URN = "urn:li:fsd_profile:ACoAADummyRaiseFaster";
+
+/** A compose link carrying profileUrn — present on connections AND non-connections. */
+const composeWithUrn = (urn = URN) =>
+  `https://www.linkedin.com/messaging/compose/?profileUrn=${encodeURIComponent(urn)}&recipient=x`;
+/** The Follow-primary / non-connection variant: compose link, no profileUrn. */
+const composeWithoutUrn = "https://www.linkedin.com/messaging/compose/?recipient=raise-faster";
+
+// ─── fake page ───────────────────────────────────────────────────────────────
+
+interface Profile {
+  hasTopCard: boolean;
+  cardText: string;
+  /** visible <p> elements in the card; the degree badge is <p>· 1st</p> */
+  paras: string[];
+  /** href of the compose link INSIDE the person's own top card */
+  composeHref: string | null;
+  /** a Connect CTA inside the top card */
+  connectCta: boolean;
+  /** the person's own vanity-matched Connect link, page-wide */
+  ownConnectHref: string | null;
+  pendingBadges: number;
+  /** compose links belonging to OTHER people, outside the top card */
+  sidebarComposeHrefs: string[];
+}
+
+const profile = (p: Partial<Profile> = {}): Profile => ({
+  hasTopCard: true,
+  cardText: "",
+  paras: [],
+  composeHref: null,
+  connectCta: false,
+  ownConnectHref: null,
+  pendingBadges: 0,
+  sidebarComposeHrefs: [],
+  ...p,
+});
+
+interface Trace { typeaheadQueried: boolean; gotos: string[] }
+
+type Scope = "page" | "topCard";
+
+class FakeLocator {
+  p: Profile;
+  t: Trace;
+  sel: string;
+  scope: Scope;
+  constructor(p: Profile, t: Trace, sel: string, scope: Scope = "page") {
+    this.p = p; this.t = t; this.sel = sel; this.scope = scope;
+  }
+  hasText: string | RegExp | null = null;
+  first(): FakeLocator { return this; }
+  nth(): FakeLocator { return this; }
+  filter(o?: { hasText?: string | RegExp }): FakeLocator {
+    if (o?.hasText === undefined) return this;
+    const l = new FakeLocator(this.p, this.t, this.sel, this.scope);
+    l.hasText = o.hasText; return l;
+  }
+  locator(sel: string): FakeLocator { return new FakeLocator(this.p, this.t, sel, "topCard"); }
+
+  private isCompose() { return this.sel.includes("/messaging/compose"); }
+
+  async count(): Promise<number> {
+    if (this.scope === "topCard") {
+      if (!this.p.hasTopCard) return 0;
+      if (this.sel === "p" || this.sel === "p:visible") {
+        const f = this.hasText;
+        return this.p.paras.filter(t => {
+          const n = t.replace(/\s+/g, " ").trim();
+          return f === null ? true : typeof f === "string" ? n.includes(f) : f.test(n);
+        }).length;
+      }
+      if (this.isCompose()) return this.p.composeHref ? 1 : 0;
+      if (this.sel.includes("to connect") || this.sel.includes("custom-invite")) return this.p.connectCta ? 1 : 0;
+      return 0;
+    }
+    if (this.sel.includes('componentkey$="Topcard"')) return this.p.hasTopCard ? 1 : 0;
+    if (this.sel.startsWith("main section")) return 0;               // legacy layout absent
+    if (this.sel.includes("custom-invite")) return this.p.ownConnectHref ? 1 : 0;
+    if (this.sel.includes("Pending")) return this.p.pendingBadges;
+    if (this.isCompose()) return this.p.sidebarComposeHrefs.length + (this.p.composeHref ? 1 : 0);
+    if (this.sel.includes("msg-connections-typeahead")) { this.t.typeaheadQueried = true; return 0; }
+    if (this.sel.includes("msg-form__contenteditable")) return 0;
+    return 0;
+  }
+  async getAttribute(name: string): Promise<string | null> {
+    if (name !== "href") return null;
+    if (this.scope === "topCard" && this.isCompose()) return this.p.composeHref;
+    if (this.isCompose()) return this.p.sidebarComposeHrefs[0] ?? this.p.composeHref;
+    if (this.sel.includes("custom-invite")) return this.p.ownConnectHref;
+    return null;
+  }
+  /** The card itself, as returned by findTopCard(), is page-scoped. */
+  private isCard() { return this.sel.includes('componentkey$="Topcard"') || this.sel.startsWith("main section"); }
+
+  async innerText(): Promise<string> {
+    if (this.scope === "topCard" || this.isCard()) {
+      if (!this.p.hasTopCard) throw new Error("no top card");
+      return this.p.cardText;
+    }
+    return "";
+  }
+  async waitFor(): Promise<void> {
+    if ((await this.count()) === 0) throw new Error(`Timeout waiting for ${this.sel}`);
+  }
+  async click(): Promise<void> {}
+  async evaluate(): Promise<unknown> { return undefined; }
+  async isVisible(): Promise<boolean> { return (await this.count()) > 0; }
+  async type(): Promise<void> {}
+}
+
+class FakePage {
+  p: Profile;
+  t: Trace;
+  constructor(p: Profile, t: Trace) { this.p = p; this.t = t; }
+  async goto(u: string): Promise<void> { this.t.gotos.push(u); }
+  async waitForTimeout(): Promise<void> {}
+  url(): string { return URL; }
+  locator(sel: string): FakeLocator {
+    if (sel.includes("msg-connections-typeahead")) this.t.typeaheadQueried = true;
+    return new FakeLocator(this.p, this.t, sel, "page");
+  }
+  on(): void {}
+}
+
+function mk(p: Partial<Profile> = {}) {
+  const prof = profile(p);
+  const trace: Trace = { typeaheadQueried: false, gotos: [] };
+  return { page: new FakePage(prof, trace) as unknown as Page, prof, trace };
+}
+
+const topCardOf = async (page: Page): Promise<Locator | null> => findTopCard(page);
+
+// ─── assertConnectable ───────────────────────────────────────────────────────
+
+test("Follow + Message with no profileUrn is CONNECTABLE, not already-connected", async () => {
+  // The raise-faster regression: creator/Follow-primary layout renders a
+  // Message button for a NON-connection, and Connect lives in the More menu.
+  const { page } = mk({ cardText: "Raise Faster Follow Message", composeHref: composeWithoutUrn });
+  const topCard = await topCardOf(page);
+
+  await assert.doesNotReject(
+    () => assertConnectable(page, topCard, "raise-faster"),
+    "a compose link without profileUrn must not imply a connection"
+  );
+});
+
+test("a compose link WITH profileUrn is still NOT proof of a connection", async () => {
+  // Superseded Aug 2026: a confirmed non-connection (/in/raise-faster/) and a
+  // confirmed 1st-degree (/in/demo-investor-4aa78a428/) expose structurally
+  // identical profileUrn compose links, so the link proves nothing either way.
+  const { page } = mk({ cardText: "Someone Message", composeHref: composeWithUrn() });
+  const topCard = await topCardOf(page);
+
+  await assert.doesNotReject(() => assertConnectable(page, topCard, "someone"));
+});
+
+test("the 1st-degree text path still detects a connection", async () => {
+  const { page } = mk({ cardText: "Someone · 1st · Mumbai", paras: ["· 1st"], composeHref: null });
+  const topCard = await topCardOf(page);
+
+  await assert.rejects(() => assertConnectable(page, topCard, "someone"), AlreadyConnectedError);
+});
+
+test("an own Connect link short-circuits even when a compose link is present", async () => {
+  const { page } = mk({
+    cardText: "Someone Connect Message",
+    composeHref: composeWithUrn(),
+    ownConnectHref: "/preload/custom-invite/?vanityName=someone",
+  });
+  const topCard = await topCardOf(page);
+
+  await assert.doesNotReject(() => assertConnectable(page, topCard, "someone"));
+});
+
+test("a Connect CTA inside the top card short-circuits too", async () => {
+  const { page } = mk({ cardText: "Someone Connect Message", composeHref: composeWithUrn(), connectCta: true });
+  const topCard = await topCardOf(page);
+
+  await assert.doesNotReject(() => assertConnectable(page, topCard, null));
+});
+
+test("Pending wins over a compose link", async () => {
+  const { page } = mk({ cardText: "Someone Pending Message", composeHref: composeWithUrn() });
+  const topCard = await topCardOf(page);
+
+  await assert.rejects(() => assertConnectable(page, topCard, "someone"), PendingInviteError);
+});
+
+test("sidebar compose links belonging to other people are ignored", async () => {
+  // Page-wide compose links exist for suggested profiles; only the target's own
+  // top card may be consulted.
+  const { page } = mk({
+    cardText: "Someone Follow",
+    composeHref: null,
+    sidebarComposeHrefs: [composeWithUrn("urn:li:fsd_profile:STRANGER")],
+  });
+  const topCard = await topCardOf(page);
+
+  await assert.doesNotReject(
+    () => assertConnectable(page, topCard, "someone"),
+    "another person's compose link must never mark this target connected"
+  );
+});
+
+// ─── visitProfile ────────────────────────────────────────────────────────────
+
+test("visitProfile: compose href without profileUrn is NOT first-degree", async () => {
+  const { page } = mk({ cardText: "Raise Faster Follow Message", composeHref: composeWithoutUrn });
+
+  assert.deepEqual(await visitProfile(page, URL), { degree: "not_first_degree", isFirstDegree: false, messagingUrn: null });
+});
+
+test("visitProfile: the '1st' badge decides first-degree; the URN is then extracted", async () => {
+  const { page } = mk({ cardText: "Someone · 1st · Message", paras: ["· 1st"], composeHref: composeWithUrn() });
+
+  assert.deepEqual(await visitProfile(page, URL), { degree: "first_degree", isFirstDegree: true, messagingUrn: URN });
+});
+
+test("a compose link alone never yields first-degree, with or without a URN", async () => {
+  // The isFirstDegree=true / messagingUrn=null pair is now REACHABLE (a 1st
+  // badge with no compose link) but harmless: the typeahead it used to feed has
+  // been deleted, so sendMessage() raises MessagingUrnUnresolvedError instead.
+  for (const p of [
+    { cardText: "Follow Message", composeHref: composeWithoutUrn },
+    { cardText: "Follow Message", composeHref: composeWithUrn() },
+    { cardText: "", composeHref: null },
+  ]) {
+    const { page } = mk(p);
+    assert.deepEqual(await visitProfile(page, URL), { degree: "not_first_degree", isFirstDegree: false, messagingUrn: null },
+      `compose link must not imply connection: ${JSON.stringify(p)}`);
+  }
+});
+
+// ─── sendMessage ─────────────────────────────────────────────────────────────
+
+test("sendMessage refuses a non-connection and never touches the typeahead", async () => {
+  const { page, trace } = mk({ cardText: "Raise Faster Follow Message", composeHref: composeWithoutUrn });
+
+  await assert.rejects(() => sendMessage(page, "raise-faster", "hi", URL, null), NotConnectedError);
+  assert.equal(trace.typeaheadQueried, false, "name-search typeahead must never be invoked");
+  assert.ok(
+    !trace.gotos.some(u => u.includes("/messaging/thread/new")),
+    `must not open the new-thread composer, got ${JSON.stringify(trace.gotos)}`
+  );
+});

--- a/tests/message-authorization.test.ts
+++ b/tests/message-authorization.test.ts
@@ -1,0 +1,212 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "playwright";
+
+const { sendMessage, NotConnectedError, MessagingUrnUnresolvedError } =
+  await import("@/lib/linkedin/message");
+
+const PROFILE = "https://www.linkedin.com/in/someone-123/";
+const LIVE_URN = "urn:li:fsd_profile:ACoAALIVEurn";
+const CACHED_URN = "urn:li:fsd_profile:ACoAACACHEDurn";
+const composeHrefFor = (urn: string) =>
+  `/messaging/compose/?profileUrn=${encodeURIComponent(urn)}&recipient=x&screenContext=NON_SELF_PROFILE_VIEW`;
+
+// ─── fake page ───────────────────────────────────────────────────────────────
+// Models the REAL control flow so the cached-URN bypass is observable:
+//   visitProfile()      → goto(profileUrl) then reads the card
+//   openComposeByUrn()  → goto(/messaging/compose/?profileUrn=…) then waits for
+//                         div.msg-form__contenteditable
+//   sendFromComposeBox()→ clicks that input, then button.msg-form__send-button
+// The card models the live DOM contract: the degree badge is its own visible
+// <p>· 1st</p>; the Message compose link is a separate anchor.
+
+interface Doc {
+  /** visible <p> elements in the top card; badge is "· 1st" */
+  paras: string[];
+  /** href of the card's Message compose link (the LIVE URN source) */
+  composeHref: string | null;
+  /** whether the compose page renders its input (openComposeByUrn success) */
+  composeOpens: boolean;
+}
+
+interface Trace {
+  gotos: string[];
+  visitCount: number;
+  composeOpenedWith: string[];
+  sent: boolean;
+  typeaheadTouched: boolean;
+}
+
+const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+
+class FL {
+  d: Doc; t: Trace; sel: string; scope: "page" | "card";
+  hasText: string | RegExp | null = null;
+  constructor(d: Doc, t: Trace, sel: string, scope: "page" | "card" = "page") {
+    this.d = d; this.t = t; this.sel = sel; this.scope = scope;
+  }
+  private clone(): FL { const l = new FL(this.d, this.t, this.sel, this.scope); l.hasText = this.hasText; return l; }
+  first(): FL { return this; }
+  nth(): FL { return this; }
+  filter(o?: { hasText?: string | RegExp }): FL {
+    const l = this.clone(); if (o?.hasText !== undefined) l.hasText = o.hasText; return l;
+  }
+  locator(sel: string): FL {
+    const isCard = this.sel.includes('componentkey$="Topcard"');
+    return new FL(this.d, this.t, sel, isCard ? "card" : this.scope);
+  }
+  private matches(): number {
+    if (this.sel.includes('componentkey$="Topcard"')) return 1;          // card always present
+    if (this.sel.startsWith("main section")) return 0;
+    if (this.sel === "p" || this.sel === "p:visible") {
+      if (this.scope !== "card") return 0;
+      const f = this.hasText;
+      return this.d.paras.filter(x => {
+        const n = norm(x);
+        return f === null ? true : typeof f === "string" ? n.includes(f) : f.test(n);
+      }).length;
+    }
+    if (this.sel.includes("/messaging/compose")) return this.scope === "card" && this.d.composeHref ? 1 : 0;
+    if (this.sel.includes("msg-form__contenteditable")) return this.d.composeOpens ? 1 : 0;
+    if (this.sel.includes("msg-form__send-button")) return this.d.composeOpens ? 1 : 0;
+    if (this.sel.includes("msg-connections-typeahead")) { this.t.typeaheadTouched = true; return 0; }
+    return 0;
+  }
+  async count(): Promise<number> { return this.matches(); }
+  async isVisible(): Promise<boolean> { return this.matches() > 0; }
+  async getAttribute(n: string): Promise<string | null> {
+    if (n === "href" && this.sel.includes("/messaging/compose") && this.scope === "card") return this.d.composeHref;
+    return null;
+  }
+  async innerText(): Promise<string> { return this.scope === "card" ? this.d.paras.join(" ") : ""; }
+  async waitFor(): Promise<void> { if (this.matches() === 0) throw new Error(`Timeout ${this.sel}`); }
+  async click(): Promise<void> {
+    if (this.sel.includes("msg-form__send-button")) this.t.sent = true;
+  }
+  async press(): Promise<void> {}
+  async pressSequentially(): Promise<void> {}
+  async evaluate(): Promise<unknown> { return undefined; }
+  async type(): Promise<void> {}
+}
+
+class FP {
+  d: Doc; t: Trace;
+  constructor(d: Doc, t: Trace) { this.d = d; this.t = t; }
+  url(): string { return PROFILE; }
+  async goto(u: string): Promise<void> {
+    this.t.gotos.push(u);
+    if (u.startsWith(PROFILE)) this.t.visitCount++;
+    if (u.includes("/messaging/compose")) {
+      const m = u.match(/profileUrn=([^&]+)/);
+      this.t.composeOpenedWith.push(m ? decodeURIComponent(m[1]) : "(none)");
+    }
+    if (u.includes("thread/new")) this.t.typeaheadTouched = true;
+  }
+  async waitForTimeout(): Promise<void> {}
+  async evaluate(): Promise<unknown> { return undefined; }
+  locator(sel: string): FL {
+    if (sel.includes("msg-connections-typeahead")) this.t.typeaheadTouched = true;
+    return new FL(this.d, this.t, sel, "page");
+  }
+}
+
+function mk(d: Partial<Doc> = {}) {
+  const doc: Doc = { paras: [], composeHref: null, composeOpens: true, ...d };
+  const t: Trace = { gotos: [], visitCount: 0, composeOpenedWith: [], sent: false, typeaheadTouched: false };
+  return { page: new FP(doc, t) as unknown as Page, t };
+}
+
+const CONNECTED = ["Someone", "· 1st"];
+const NOT_CONNECTED = ["Someone", "Follow", "Message"];
+
+// ─── A ───────────────────────────────────────────────────────────────────────
+
+test("A cached URN must NOT authorize a send when the live profile is not first-degree", async () => {
+  const { page, t } = mk({ paras: NOT_CONNECTED, composeHref: composeHrefFor(LIVE_URN) });
+
+  await assert.rejects(() => sendMessage(page, "Someone", "hi", PROFILE, CACHED_URN), NotConnectedError);
+
+  assert.deepEqual(t.composeOpenedWith, [], "openComposeByUrn must never be reached");
+  assert.equal(t.sent, false, "nothing may be sent");
+});
+
+// ─── B ───────────────────────────────────────────────────────────────────────
+
+test("B connected + cached URN + no live URN → live check runs first, cached URN used as address", async () => {
+  const { page, t } = mk({ paras: CONNECTED, composeHref: null });
+
+  const r = await sendMessage(page, "Someone", "hi", PROFILE, CACHED_URN);
+
+  assert.equal(t.visitCount, 1, "the profile must be visited before composing");
+  assert.ok(t.gotos.findIndex(u => u.startsWith(PROFILE)) < t.gotos.findIndex(u => u.includes("/messaging/compose")),
+    `visit must precede compose, got ${JSON.stringify(t.gotos)}`);
+  assert.deepEqual(t.composeOpenedWith, [CACHED_URN]);
+  assert.equal(t.sent, true);
+  assert.equal(r.isFirstDegree, true);
+});
+
+// ─── C ───────────────────────────────────────────────────────────────────────
+
+test("C the live URN is preferred over the cached URN", async () => {
+  const { page, t } = mk({ paras: CONNECTED, composeHref: composeHrefFor(LIVE_URN) });
+
+  const r = await sendMessage(page, "Someone", "hi", PROFILE, CACHED_URN);
+
+  assert.deepEqual(t.composeOpenedWith, [LIVE_URN], "must address the live URN, not the stale cached one");
+  assert.equal(r.messagingUrn, LIVE_URN);
+  assert.equal(t.sent, true);
+});
+
+// ─── D ───────────────────────────────────────────────────────────────────────
+
+test("D connected but no URN anywhere → MessagingUrnUnresolvedError, no send", async () => {
+  const { page, t } = mk({ paras: CONNECTED, composeHref: null });
+
+  await assert.rejects(() => sendMessage(page, "Someone", "hi", PROFILE, null), MessagingUrnUnresolvedError);
+
+  assert.deepEqual(t.composeOpenedWith, []);
+  assert.equal(t.sent, false);
+});
+
+// ─── E ───────────────────────────────────────────────────────────────────────
+
+test("E cached URN present but live profile not connected → NotConnectedError, no bypass", async () => {
+  const { page, t } = mk({ paras: NOT_CONNECTED, composeHref: null });
+
+  await assert.rejects(() => sendMessage(page, "Someone", "hi", PROFILE, CACHED_URN), NotConnectedError);
+
+  assert.equal(t.visitCount, 1, "the live check must still run");
+  assert.deepEqual(t.composeOpenedWith, []);
+  assert.equal(t.sent, false);
+});
+
+// ─── F ───────────────────────────────────────────────────────────────────────
+
+test("F visitProfile runs exactly once, before any compose or send", async () => {
+  const { page, t } = mk({ paras: CONNECTED, composeHref: composeHrefFor(LIVE_URN) });
+
+  await sendMessage(page, "Someone", "hi", PROFILE, CACHED_URN);
+
+  assert.equal(t.visitCount, 1, `expected exactly one profile visit, got ${t.visitCount}`);
+  assert.equal(t.gotos[0], PROFILE, `the first navigation must be the profile, got ${JSON.stringify(t.gotos)}`);
+});
+
+test("F2 a failed compose open does not fall back to any recipient search", async () => {
+  const { page, t } = mk({ paras: CONNECTED, composeHref: composeHrefFor(LIVE_URN), composeOpens: false });
+
+  await assert.rejects(() => sendMessage(page, "Someone", "hi", PROFILE, CACHED_URN), MessagingUrnUnresolvedError);
+
+  assert.equal(t.sent, false);
+  assert.equal(t.typeaheadTouched, false, "no typeahead / thread-new fallback may exist");
+  assert.ok(!t.gotos.some(u => u.includes("thread/new")));
+});
+
+// ─── G ───────────────────────────────────────────────────────────────────────
+
+test("G message.ts contains no name-search fallback of any kind", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const src = await readFile("lib/linkedin/message.ts", "utf8");
+  for (const banned of ["sendMessageViaTypeahead", "resultNameMatches", "msg-connections-typeahead", "thread/new"]) {
+    assert.ok(!src.includes(banned), `message.ts must not reference ${banned}`);
+  }
+});

--- a/tests/runner-claim.test.ts
+++ b/tests/runner-claim.test.ts
@@ -1,0 +1,163 @@
+import test, { after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// lib/db.ts resolves the DB path on first getDb(), so set it before loading.
+const dbDir = mkdtempSync(join(tmpdir(), "linki-runner-claim-test-"));
+process.env.LINKI_DB_PATH = join(dbDir, "test.db");
+process.env.NEXTAUTH_SECRET ??= "test-secret-for-runner-claim-tests";
+
+const { trClaim } = await import("@/lib/linkedin/runner");
+const { getDb } = await import("@/lib/db");
+
+after(() => {
+  try { getDb().close(); } catch { /* never opened, or already closed */ }
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const iso = (msFromNow: number) => new Date(Date.now() + msFromNow).toISOString();
+
+let seq = 0;
+/**
+ * A run_profile_tracks row with the given state / next_step_at, plus the
+ * run + run_profile parents its foreign keys require.
+ */
+function makeTrack(state = "in_progress", nextStepAt: string | null = iso(-60_000)): string {
+  const n = ++seq;
+  const runId = `run-${n}`;
+  const profileId = `profile-${n}`;
+  const id = `track-${n}`;
+  const db = getDb();
+  db.prepare("INSERT INTO runs (id, status) VALUES (?, 'running')").run(runId);
+  db.prepare("INSERT INTO run_profiles (id, run_id) VALUES (?, ?)").run(profileId, runId);
+  db.prepare(
+    `INSERT INTO run_profile_tracks (id, run_profile_id, track, state, current_step, next_step_at)
+     VALUES (?, ?, 'linkedin', ?, 0, ?)`
+  ).run(id, profileId, state, nextStepAt);
+  return id;
+}
+
+const trackRow = (id: string) =>
+  getDb()
+    .prepare("SELECT state, current_step, next_step_at FROM run_profile_tracks WHERE id = ?")
+    .get(id) as { state: string; current_step: number; next_step_at: string | null };
+
+// ─── (1) a due track is claimable exactly once ───────────────────────────────
+
+test("the first claim on a due track succeeds and the second immediately fails", () => {
+  const id = makeTrack("in_progress", iso(-60_000));
+
+  assert.equal(trClaim(getDb(), id), true, "first claim should win");
+  assert.equal(trClaim(getDb(), id), false, "second claim must lose — the lease is now in the future");
+});
+
+test("a track whose next_step_at is NULL is due and claimable once", () => {
+  const id = makeTrack("in_progress", null);
+
+  assert.equal(trClaim(getDb(), id), true);
+  assert.equal(trClaim(getDb(), id), false);
+});
+
+// ─── (2) a future track is not claimable ─────────────────────────────────────
+
+test("a track scheduled in the future cannot be claimed", () => {
+  const id = makeTrack("in_progress", iso(6 * 3600_000));
+  const before = trackRow(id).next_step_at;
+
+  assert.equal(trClaim(getDb(), id), false);
+  assert.equal(trackRow(id).next_step_at, before, "a lost claim must not move next_step_at");
+});
+
+// ─── (3) only in_progress tracks are claimable ───────────────────────────────
+
+for (const state of ["pending", "completed", "failed", "skipped"]) {
+  test(`a due track in state '${state}' cannot be claimed`, () => {
+    const id = makeTrack(state, iso(-60_000));
+    const before = trackRow(id).next_step_at;
+
+    assert.equal(trClaim(getDb(), id), false);
+    assert.equal(trackRow(id).next_step_at, before);
+  });
+}
+
+// ─── (4) two simulated runners race for the same track ───────────────────────
+
+test("two runner passes over the same due track let exactly one proceed", () => {
+  // Mirrors the real loop: each "runner" selects due tracks, then claims before
+  // executing. Both see the row as due — only the claim can separate them.
+  const id = makeTrack("in_progress", iso(-60_000));
+
+  const dueFor = (): string[] =>
+    getDb()
+      .prepare(
+        `SELECT id FROM run_profile_tracks
+         WHERE id = ? AND state = 'in_progress'
+           AND (next_step_at IS NULL OR datetime(next_step_at) <= datetime('now'))`
+      )
+      .all(id)
+      .map(r => (r as { id: string }).id);
+
+  const runnerA = dueFor();
+  const runnerB = dueFor();
+  assert.deepEqual(runnerA, [id], "runner A sees it as due");
+  assert.deepEqual(runnerB, [id], "runner B sees the same row as due — this is the race");
+
+  const executed = [...runnerA, ...runnerB].filter(t => trClaim(getDb(), t));
+
+  assert.equal(executed.length, 1, "exactly one runner may execute the track");
+});
+
+// ─── (5) the lease, and that normal scheduling still wins afterwards ─────────
+
+test("a successful claim pushes next_step_at into the future as a lease", () => {
+  const id = makeTrack("in_progress", iso(-60_000));
+
+  assert.equal(trClaim(getDb(), id), true);
+
+  const after = trackRow(id).next_step_at;
+  assert.ok(after, "the lease must be set");
+  const msAhead = new Date(after).getTime() - Date.now();
+  assert.ok(msAhead > 0, `lease must be in the future, was ${msAhead}ms`);
+  assert.ok(msAhead <= 15 * 60_000 + 1000, `lease must not exceed 15 minutes, was ${msAhead}ms`);
+});
+
+test("the lease uses the same ISO-UTC format as every other next_step_at write", () => {
+  const id = makeTrack("in_progress", iso(-60_000));
+  trClaim(getDb(), id);
+
+  const after = trackRow(id).next_step_at!;
+  assert.match(after, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  // and it must still be comparable by the due-query's datetime() predicate
+  const stillDue = getDb()
+    .prepare("SELECT datetime(next_step_at) <= datetime('now') AS due FROM run_profile_tracks WHERE id = ?")
+    .get(id) as { due: number };
+  assert.equal(stillDue.due, 0, "a leased track must not read as due");
+});
+
+test("the lease is transient — a later reschedule overwrites it", () => {
+  // The lease must not become a permanent second meaning for next_step_at:
+  // whatever the step does at the end (here, the 6h connection recheck) wins.
+  const id = makeTrack("in_progress", iso(-60_000));
+  assert.equal(trClaim(getDb(), id), true);
+  const leased = trackRow(id).next_step_at!;
+
+  const sixHoursOut = iso(6 * 3600_000);
+  getDb().prepare("UPDATE run_profile_tracks SET next_step_at = ? WHERE id = ?").run(sixHoursOut, id);
+
+  const final = trackRow(id).next_step_at!;
+  assert.equal(final, sixHoursOut);
+  assert.ok(new Date(final).getTime() > new Date(leased).getTime(), "the 6h recheck must outlast the lease");
+});
+
+test("a claim does not touch state or current_step", () => {
+  const id = makeTrack("in_progress", iso(-60_000));
+  assert.equal(trClaim(getDb(), id), true);
+
+  const row = trackRow(id);
+  assert.equal(row.state, "in_progress");
+  assert.equal(row.current_step, 0);
+});

--- a/tests/runner-connect-idempotence.test.ts
+++ b/tests/runner-connect-idempotence.test.ts
@@ -1,0 +1,257 @@
+import test, { after, mock } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// lib/db.ts resolves the DB path on first getDb(), so set it before loading.
+const dbDir = mkdtempSync(join(tmpdir(), "linki-connect-idem-test-"));
+process.env.LINKI_DB_PATH = join(dbDir, "test.db");
+process.env.NEXTAUTH_SECRET ??= "test-secret-for-connect-idempotence-tests";
+
+// ─── sandbox ─────────────────────────────────────────────────────────────────
+// Every LinkedIn entry point the connect step can reach is replaced before the
+// runner is loaded, so these tests can never open a browser or touch a real
+// account. getLinkedinUrl short-circuits on a /in/ URL, so no other module is
+// involved once these two are mocked.
+
+// @types/node is pinned at v20, which still types mock.module's old
+// `namedExports` option. Node 24 deprecates that in favour of `exports`, so
+// call the runtime-correct shape through a locally narrowed type.
+// Bound, not detached — mock.module reads private state off `mock`.
+const mockModule = mock.module.bind(mock) as unknown as
+  (specifier: string, options: { exports: Record<string, unknown> }) => void;
+
+const realConnect = await import("@/lib/linkedin/connect");
+const { PendingInviteError, InviteNotSentError, SessionExpiredError, InviteUiError } = realConnect;
+
+/** What sendConnectionRequest should do on the next call. */
+let sendBehaviour: () => void | never = () => {};
+let sendCalls = 0;
+
+mockModule("@/lib/linkedin/connect", {
+  exports: {
+    ...realConnect,
+    sendConnectionRequest: async () => { sendCalls++; sendBehaviour(); },
+  },
+});
+
+const realSession = await import("@/lib/linkedin/session");
+let pagesClosed = 0;
+mockModule("@/lib/linkedin/session", {
+  exports: {
+    ...realSession,
+    getSessionPage: async () => ({ close: async () => { pagesClosed++; } }),
+    saveSessionState: async () => {},
+  },
+});
+
+const { executeStep } = await import("@/lib/linkedin/runner");
+const { getDb } = await import("@/lib/db");
+
+after(() => {
+  try { getDb().close(); } catch { /* never opened, or already closed */ }
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const CONNECT_STEP = {
+  id: "step-connect",
+  step_order: 1,
+  track: "linkedin",
+  step_type: "connect",
+  template_id: null,
+  delay_seconds: 0,
+  connect_note: null,
+  message_body: null,
+  email_subject: null,
+  email_body: null,
+  ai_enabled: 0,
+  ai_model: null,
+  ai_prompt: null,
+  ai_max_words: null,
+  ai_language: null,
+  email_position: 1,
+  message_position: 1,
+  email_signature: null,
+};
+
+// 24/7 window so enforceSchedule never reschedules and the step always runs.
+const LIMITS = {
+  active_hours_start: 0,
+  active_hours_end: 24,
+  timezone: "UTC",
+  working_days: "1,2,3,4,5,6,7",
+  daily_connection_limit: 20,
+  daily_message_limit: 50,
+  daily_inmail_limit: 15,
+};
+
+let seq = 0;
+/** A full run/profile/track/target chain ready for the connect step. */
+function scenario(opts: { connectionRequestedAt?: string | null } = {}) {
+  const n = ++seq;
+  const runId = `run-${n}`;
+  const profileId = `profile-${n}`;
+  const trackId = `track-${n}`;
+  const targetId = `target-${n}`;
+  const db = getDb();
+
+  db.prepare("INSERT INTO runs (id, status) VALUES (?, 'running')").run(runId);
+  db.prepare("INSERT INTO targets (id, linkedin_url, full_name, connection_requested_at) VALUES (?, ?, ?, ?)")
+    .run(targetId, `https://www.linkedin.com/in/test-${n}/`, `Test Person ${n}`, opts.connectionRequestedAt ?? null);
+  db.prepare("INSERT INTO run_profiles (id, run_id, target_id) VALUES (?, ?, ?)").run(profileId, runId, targetId);
+  db.prepare(
+    `INSERT INTO run_profile_tracks (id, run_profile_id, track, state, current_step, next_step_at)
+     VALUES (?, ?, 'linkedin', 'in_progress', 0, NULL)`
+  ).run(trackId, profileId);
+
+  const target = db.prepare("SELECT * FROM targets WHERE id = ?").get(targetId);
+  const tr = {
+    ...(db.prepare("SELECT * FROM run_profile_tracks WHERE id = ?").get(trackId) as object),
+    run_id: runId,
+    target_id: targetId,
+    email_account_id: null,
+    account_id: `account-${n}`,
+    workflow_id: `workflow-${n}`,
+    connection_requested_at: opts.connectionRequestedAt ?? null,
+  };
+
+  return { runId, trackId, targetId, tr, target };
+}
+
+const run = (s: ReturnType<typeof scenario>) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  executeStep(getDb(), s.runId, s.tr as any, s.target as any, [CONNECT_STEP] as any, "account-x", LIMITS);
+
+const trackOf = (id: string) =>
+  getDb().prepare("SELECT state, current_step, next_step_at, error_message FROM run_profile_tracks WHERE id = ?").get(id) as
+    { state: string; current_step: number; next_step_at: string | null; error_message: string | null };
+
+const requestedAtOf = (id: string) =>
+  (getDb().prepare("SELECT connection_requested_at FROM targets WHERE id = ?").get(id) as
+    { connection_requested_at: string | null }).connection_requested_at;
+
+/** Hours between now and an ISO timestamp. */
+const hoursAhead = (iso: string) => (new Date(iso).getTime() - Date.now()) / 3600_000;
+
+function reset(behaviour: () => void | never) {
+  sendBehaviour = behaviour;
+  sendCalls = 0;
+  pagesClosed = 0;
+}
+
+// ─── (1) already requested → no invite attempted ─────────────────────────────
+
+test("an already-requested connection is not re-sent, it just waits for the recheck", async () => {
+  reset(() => { throw new Error("sendConnectionRequest must not be called"); });
+  const requestedAt = new Date(Date.now() - 3600_000).toISOString();
+  const s = scenario({ connectionRequestedAt: requestedAt });
+
+  await run(s);
+
+  assert.equal(sendCalls, 0, "no invitation may be attempted");
+  assert.equal(requestedAtOf(s.targetId), requestedAt, "the original request time must be preserved");
+
+  const tk = trackOf(s.trackId);
+  assert.equal(tk.state, "in_progress", "must not be marked failed");
+  assert.equal(tk.current_step, 0, "must not advance past the connect step");
+  assert.ok(Math.abs(hoursAhead(tk.next_step_at!) - 6) < 0.1, "must wait the normal 6h recheck");
+});
+
+// ─── (2) PendingInviteError → treated as already requested ───────────────────
+
+test("PendingInviteError is recovered as 'already requested', not retried or failed", async () => {
+  // The lost-write crash window: LinkedIn already holds the invite but
+  // connection_requested_at was never persisted.
+  reset(() => { throw new PendingInviteError("invite already pending"); });
+  const s = scenario({ connectionRequestedAt: null });
+
+  await run(s);
+
+  assert.equal(sendCalls, 1, "exactly one attempt — the error must not trigger a retry");
+
+  const stamped = requestedAtOf(s.targetId);
+  assert.ok(stamped, "the pending invite must now be recorded so the next pass is a no-op");
+
+  const tk = trackOf(s.trackId);
+  assert.equal(tk.state, "in_progress", "a pending invite is not a run failure");
+  assert.equal(tk.error_message, null, "no error must be recorded");
+  assert.equal(tk.current_step, 0, "must not advance past the connect step");
+  assert.ok(Math.abs(hoursAhead(tk.next_step_at!) - 6) < 0.1, "must wait the normal 6h recheck");
+});
+
+test("recovering from PendingInviteError makes the next pass send nothing", async () => {
+  // End-to-end idempotence: the second pass must take the already-requested
+  // branch, which is the whole point of stamping the timestamp.
+  reset(() => { throw new PendingInviteError("invite already pending"); });
+  const s = scenario({ connectionRequestedAt: null });
+  await run(s);
+  const stampedAfterFirst = requestedAtOf(s.targetId);
+
+  // Second pass, with the track re-read from the DB as the runner would.
+  reset(() => { throw new Error("sendConnectionRequest must not be called on the retry"); });
+  const s2 = { ...s, tr: { ...s.tr, connection_requested_at: stampedAfterFirst }, target: getDb().prepare("SELECT * FROM targets WHERE id = ?").get(s.targetId) };
+  await run(s2 as ReturnType<typeof scenario>);
+
+  assert.equal(sendCalls, 0, "no second invitation");
+  assert.equal(requestedAtOf(s.targetId), stampedAfterFirst, "the original stamp must be kept");
+});
+
+test("PendingInviteError does not overwrite an existing connection_requested_at", async () => {
+  const original = new Date(Date.now() - 5 * 3600_000).toISOString();
+  reset(() => { throw new PendingInviteError("invite already pending"); });
+  // Track says not-yet-requested (stale read) while the row already has a stamp —
+  // the COALESCE must keep the true, earlier time.
+  const s = scenario({ connectionRequestedAt: null });
+  getDb().prepare("UPDATE targets SET connection_requested_at = ? WHERE id = ?").run(original, s.targetId);
+
+  await run(s);
+
+  assert.equal(requestedAtOf(s.targetId), original, "the earlier request time must survive");
+});
+
+// ─── (3) other errors still fail — no false success ──────────────────────────
+
+for (const [label, make] of [
+  ["InviteNotSentError", () => new InviteNotSentError("not sent")],
+  ["SessionExpiredError", () => new SessionExpiredError("session gone")],
+  ["InviteUiError", () => new InviteUiError("ui changed")],
+  ["a generic Error", () => new Error("boom")],
+] as const) {
+  test(`${label} still fails the track and records no connection request`, async () => {
+    reset(() => { throw make(); });
+    const s = scenario({ connectionRequestedAt: null });
+
+    await run(s);
+
+    assert.equal(sendCalls, 1);
+    assert.equal(requestedAtOf(s.targetId), null, "a failed send must NOT look like a sent invite");
+
+    const tk = trackOf(s.trackId);
+    assert.equal(tk.state, "failed", "the error must surface as a failure");
+    assert.ok(tk.error_message, "the failure reason must be recorded");
+  });
+}
+
+// ─── (4) the successful path is unchanged ────────────────────────────────────
+
+test("a successful send still records the request and schedules the 6h recheck", async () => {
+  reset(() => {});
+  const s = scenario({ connectionRequestedAt: null });
+
+  await run(s);
+
+  assert.equal(sendCalls, 1);
+  assert.equal(pagesClosed, 1, "the page must still be closed");
+
+  const stamped = requestedAtOf(s.targetId);
+  assert.ok(stamped, "connection_requested_at must be recorded");
+  assert.ok(Math.abs(hoursAhead(stamped!) - 0) < 0.1, "stamped at send time");
+
+  const tk = trackOf(s.trackId);
+  assert.equal(tk.state, "in_progress");
+  assert.equal(tk.current_step, 0, "connect waits for acceptance rather than advancing");
+  assert.ok(Math.abs(hoursAhead(tk.next_step_at!) - 6) < 0.1, "6h recheck scheduled");
+});

--- a/tests/runner-visit-degree.test.ts
+++ b/tests/runner-visit-degree.test.ts
@@ -1,0 +1,289 @@
+import test, { after, mock } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// lib/db.ts resolves the DB path on first getDb(), so set it before loading.
+const dbDir = mkdtempSync(join(tmpdir(), "linki-visit-degree-test-"));
+process.env.LINKI_DB_PATH = join(dbDir, "test.db");
+process.env.NEXTAUTH_SECRET ??= "test-secret-for-visit-degree-tests";
+
+// ─── sandbox ─────────────────────────────────────────────────────────────────
+// visitProfile and the session are replaced before the runner is loaded, so no
+// browser can open and no LinkedIn page can be reached. Each test dictates the
+// observation the visit step will see.
+
+// @types/node is pinned at v20, which still types mock.module's old
+// `namedExports` option. Node 24 deprecates that in favour of `exports`.
+// Bound, not detached — mock.module reads private state off `mock`.
+const mockModule = mock.module.bind(mock) as unknown as
+  (specifier: string, options: { exports: Record<string, unknown> }) => void;
+
+type Observation = "first_degree" | "not_first_degree" | "inconclusive";
+interface VisitResult { degree: Observation; isFirstDegree: boolean; messagingUrn: string | null }
+
+const realVisit = await import("@/lib/linkedin/visit");
+
+/** What visitProfile returns on the next call, or a throw to simulate a failure. */
+let nextVisit: VisitResult | (() => never) = { degree: "inconclusive", isFirstDegree: false, messagingUrn: null };
+let visitCalls = 0;
+
+const observe = (degree: Observation, messagingUrn: string | null = null): VisitResult => ({
+  degree,
+  isFirstDegree: degree === "first_degree",
+  messagingUrn,
+});
+
+mockModule("@/lib/linkedin/visit", {
+  exports: {
+    ...realVisit,
+    visitProfile: async () => {
+      visitCalls++;
+      if (typeof nextVisit === "function") nextVisit();
+      return nextVisit;
+    },
+  },
+});
+
+const realSession = await import("@/lib/linkedin/session");
+mockModule("@/lib/linkedin/session", {
+  exports: {
+    ...realSession,
+    getSessionPage: async () => ({ close: async () => {} }),
+    saveSessionState: async () => {},
+  },
+});
+
+const { executeStep } = await import("@/lib/linkedin/runner");
+const { getDb } = await import("@/lib/db");
+
+after(() => {
+  try { getDb().close(); } catch { /* never opened, or already closed */ }
+  rmSync(dbDir, { recursive: true, force: true });
+});
+
+// ─── fixtures ────────────────────────────────────────────────────────────────
+
+const VISIT_STEP = {
+  id: "step-visit",
+  step_order: 1,
+  track: "linkedin",
+  step_type: "visit",
+  template_id: null,
+  delay_seconds: 0,
+  connect_note: null,
+  message_body: null,
+  email_subject: null,
+  email_body: null,
+  ai_enabled: 0,
+  ai_model: null,
+  ai_prompt: null,
+  ai_max_words: null,
+  ai_language: null,
+  email_position: 1,
+  message_position: 1,
+  email_signature: null,
+};
+
+// 24/7 window so nothing reschedules and the step always runs.
+const LIMITS = {
+  active_hours_start: 0,
+  active_hours_end: 24,
+  timezone: "UTC",
+  working_days: "1,2,3,4,5,6,7",
+  daily_connection_limit: 20,
+  daily_message_limit: 50,
+  daily_inmail_limit: 15,
+};
+
+let seq = 0;
+function scenario(opts: { degree?: number | null; connectedAt?: string | null; messagingUrn?: string | null } = {}) {
+  const n = ++seq;
+  const runId = `run-${n}`;
+  const profileId = `profile-${n}`;
+  const trackId = `track-${n}`;
+  const targetId = `target-${n}`;
+  const db = getDb();
+
+  db.prepare("INSERT INTO runs (id, status) VALUES (?, 'running')").run(runId);
+  db.prepare(
+    "INSERT INTO targets (id, linkedin_url, full_name, degree, connected_at, messaging_urn) VALUES (?, ?, ?, ?, ?, ?)"
+  ).run(
+    targetId,
+    `https://www.linkedin.com/in/test-${n}/`,
+    `Test Person ${n}`,
+    opts.degree ?? null,
+    opts.connectedAt ?? null,
+    opts.messagingUrn ?? null,
+  );
+  db.prepare("INSERT INTO run_profiles (id, run_id, target_id) VALUES (?, ?, ?)").run(profileId, runId, targetId);
+  db.prepare(
+    `INSERT INTO run_profile_tracks (id, run_profile_id, track, state, current_step, next_step_at)
+     VALUES (?, ?, 'linkedin', 'in_progress', 0, NULL)`
+  ).run(trackId, profileId);
+
+  const target = db.prepare("SELECT * FROM targets WHERE id = ?").get(targetId);
+  const tr = {
+    ...(db.prepare("SELECT * FROM run_profile_tracks WHERE id = ?").get(trackId) as object),
+    run_id: runId,
+    target_id: targetId,
+    email_account_id: null,
+    account_id: `account-${n}`,
+    workflow_id: `workflow-${n}`,
+  };
+
+  return { runId, trackId, targetId, tr, target };
+}
+
+const run = (s: ReturnType<typeof scenario>) =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  executeStep(getDb(), s.runId, s.tr as any, s.target as any, [VISIT_STEP] as any, "account-x", LIMITS);
+
+const targetOf = (id: string) =>
+  getDb().prepare("SELECT degree, connected_at, messaging_urn FROM targets WHERE id = ?").get(id) as
+    { degree: number | null; connected_at: string | null; messaging_urn: string | null };
+
+const CONNECTED_AT = "2026-01-01T00:00:00.000Z";
+const URN = "urn:li:fsd_profile:ACoAAStored";
+
+// ─── H1–H2: first_degree backfill ────────────────────────────────────────────
+
+test("H1 degree=NULL + first_degree → backfills degree=1 and connected_at", async () => {
+  const s = scenario({ degree: null });
+  nextVisit = observe("first_degree");
+
+  await run(s);
+
+  const t = targetOf(s.targetId);
+  assert.equal(t.degree, 1);
+  assert.ok(t.connected_at, "connected_at must be stamped");
+});
+
+test("H2 degree=1 + first_degree → no rewrite, connected_at preserved", async () => {
+  const s = scenario({ degree: 1, connectedAt: CONNECTED_AT });
+  nextVisit = observe("first_degree");
+
+  await run(s);
+
+  assert.deepEqual(targetOf(s.targetId), { degree: 1, connected_at: CONNECTED_AT, messaging_urn: null });
+});
+
+// ─── H3–H4: not_first_degree clearing ────────────────────────────────────────
+
+test("H3 degree=1 + not_first_degree → clears degree AND connected_at", async () => {
+  const s = scenario({ degree: 1, connectedAt: CONNECTED_AT });
+  nextVisit = observe("not_first_degree");
+
+  await run(s);
+
+  const t = targetOf(s.targetId);
+  assert.equal(t.degree, null, "a disproven connection must be cleared");
+  assert.equal(t.connected_at, null);
+});
+
+test("H4 degree=NULL + not_first_degree → nothing written", async () => {
+  const s = scenario({ degree: null });
+  nextVisit = observe("not_first_degree");
+
+  await run(s);
+
+  assert.deepEqual(targetOf(s.targetId), { degree: null, connected_at: null, messaging_urn: null });
+});
+
+// ─── H5–H6 / I: inconclusive must never clear ────────────────────────────────
+
+test("I (THE DANGEROUS CASE) degree=1 + inconclusive → connection MUST survive", async () => {
+  // A missing top card means the card was never inspected — page still
+  // rendering, layout drift, a 404, or an auth wall. Clearing here would erase
+  // a correct connection and silently re-fire a connect step at a real contact.
+  const s = scenario({ degree: 1, connectedAt: CONNECTED_AT, messagingUrn: URN });
+  nextVisit = observe("inconclusive");
+
+  await run(s);
+
+  assert.deepEqual(targetOf(s.targetId), { degree: 1, connected_at: CONNECTED_AT, messaging_urn: URN },
+    "an inconclusive visit must leave the row completely untouched");
+});
+
+test("H6 degree=NULL + inconclusive → remains NULL", async () => {
+  const s = scenario({ degree: null });
+  nextVisit = observe("inconclusive");
+
+  await run(s);
+
+  assert.deepEqual(targetOf(s.targetId), { degree: null, connected_at: null, messaging_urn: null });
+});
+
+test("I2 an inconclusive visit carrying a URN still writes no degree", async () => {
+  // Defence in depth: even if a URN somehow accompanied an inconclusive result,
+  // it is an address, never evidence of a connection.
+  const s = scenario({ degree: null });
+  nextVisit = { degree: "inconclusive", isFirstDegree: false, messagingUrn: URN };
+
+  await run(s);
+
+  assert.equal(targetOf(s.targetId).degree, null);
+});
+
+// ─── H7: non-1 degrees are not rewritten ─────────────────────────────────────
+
+test("H7 degree=2 + not_first_degree → left as 2, not nulled", async () => {
+  const s = scenario({ degree: 2 });
+  nextVisit = observe("not_first_degree");
+
+  await run(s);
+
+  assert.equal(targetOf(s.targetId).degree, 2, "only a stale degree=1 is the visit step's business");
+});
+
+test("H7b degree=3 + inconclusive → left as 3", async () => {
+  const s = scenario({ degree: 3 });
+  nextVisit = observe("inconclusive");
+
+  await run(s);
+
+  assert.equal(targetOf(s.targetId).degree, 3);
+});
+
+// ─── H8: messaging_urn is never cleared ──────────────────────────────────────
+
+test("H8 messaging_urn survives a stale-degree clear", async () => {
+  const s = scenario({ degree: 1, connectedAt: CONNECTED_AT, messagingUrn: URN });
+  nextVisit = observe("not_first_degree");
+
+  await run(s);
+
+  const t = targetOf(s.targetId);
+  assert.equal(t.degree, null, "degree cleared");
+  assert.equal(t.messaging_urn, URN, "the URN is an address — message.ts re-verifies before using it");
+});
+
+test("H8b a first_degree visit still caches a newly seen URN", async () => {
+  const s = scenario({ degree: null });
+  nextVisit = observe("first_degree", URN);
+
+  await run(s);
+
+  assert.equal(targetOf(s.targetId).messaging_urn, URN);
+});
+
+// ─── exceptions preserve existing behaviour ──────────────────────────────────
+
+test("a thrown visit fails the track and writes no degree at all", async () => {
+  const s = scenario({ degree: 1, connectedAt: CONNECTED_AT });
+  nextVisit = () => { throw new Error("Timeout 30000ms exceeded"); };
+
+  await run(s);
+
+  assert.deepEqual(targetOf(s.targetId), { degree: 1, connected_at: CONNECTED_AT, messaging_urn: null },
+    "a navigation/DOM failure must never touch connection state");
+  const tr = getDb().prepare("SELECT state FROM run_profile_tracks WHERE id = ?").get(s.trackId) as { state: string };
+  assert.equal(tr.state, "failed");
+
+  nextVisit = observe("inconclusive"); // reset for any later test
+});
+
+test("the visit step actually ran the visit in every case above", () => {
+  assert.ok(visitCalls >= 10, `expected the mocked visitProfile to be exercised, got ${visitCalls}`);
+});

--- a/tests/slice-c-connection-state.test.ts
+++ b/tests/slice-c-connection-state.test.ts
@@ -1,0 +1,463 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Page, Locator } from "playwright";
+
+const { assertConnectable, openInviteDialog, findTopCard, AlreadyConnectedError, PendingInviteError, InviteUiError } =
+  await import("@/lib/linkedin/connect");
+const { visitProfile } = await import("@/lib/linkedin/visit");
+const message = await import("@/lib/linkedin/message");
+
+const VANITY = "raise-faster";
+const URL = `https://www.linkedin.com/in/${VANITY}/`;
+
+// Observed live (Aug 2026). BOTH a non-connection and a confirmed 1st-degree
+// connection expose this identical shape — profileUrn included — which is why
+// it can never be a connection signal.
+const COMPOSE_HREF =
+  "/messaging/compose/?profileUrn=urn%3Ali%3Afsd_profile%3AACoAADmObfoB&recipient=ACoAADmObfoB&screenContext=NON_SELF_PROFILE_VIEW&interop=msgOverlay";
+const connectHref = (v: string) => `/preload/custom-invite/?vanityName=${v}`;
+
+// ─── fake DOM ────────────────────────────────────────────────────────────────
+// Faithful to the observed markup:
+//   <a role="menuitem" href="/preload/custom-invite/?vanityName=…"
+//      componentkey="ConnectButtonstate:invitation:urn:li:member:…_connect">
+//     <div>Connect</div>          ← label nested, so :text-is() does NOT match
+//     <svg aria-hidden="true">    ← icon
+//   </a>
+// aria-label is null on every item; the menu has no id; More has no aria-controls.
+
+interface Item { text: string; href?: string | null; componentkey?: string | null }
+interface MoreBtn { aria: string; inCard: boolean }
+
+interface Doc {
+  hasTopCard: boolean;
+  cardText: string;
+  /**
+   * The card's <p> elements, as observed live: the degree badge is its own
+   * <p>· 1st</p>, and LinkedIn also ships HIDDEN variants (a connected card
+   * carried <p>· 2nd</p> hidden alongside it), so visibility is load-bearing.
+   */
+  paras: Array<{ text: string; visible: boolean }>;
+  composeHref: string | null;
+  /** the person's own Connect CTA in the main card (page-wide custom-invite anchor) */
+  ownConnectHref: string | null;
+  cardConnectCta: boolean;
+  /** Pending affordance inside the target's own card */
+  cardPending: boolean;
+  mores: MoreBtn[];
+  menuItems: Item[];
+  /** extra visible menus, to model ambiguity */
+  extraVisibleMenus: number;
+  menuOpens: boolean;
+  sendButtonAfterConnect: boolean;
+}
+
+const doc = (d: Partial<Doc> = {}): Doc => ({
+  hasTopCard: true, cardText: "Diana C. Follow Message More", paras: [], composeHref: null,
+  ownConnectHref: null, cardConnectCta: false, cardPending: false,
+  mores: [], menuItems: [], extraVisibleMenus: 0, menuOpens: true, sendButtonAfterConnect: true, ...d,
+});
+
+interface Trace { clicked: string[]; typeahead: boolean }
+
+type N =
+  | { k: "card" } | { k: "more"; b: MoreBtn } | { k: "menu" }
+  | { k: "item"; it: Item } | { k: "anchor"; href: string } | { k: "send" } | { k: "pending" }
+  | { k: "para"; text: string };
+
+const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+const attrSub = (sel: string, a: string) => sel.match(new RegExp(`\\[${a}\\*=["']([^"']+)["']`))?.[1] ?? null;
+const attrSuffix = (sel: string, a: string) => sel.match(new RegExp(`\\[${a}\\$=["']([^"']+)["']`))?.[1] ?? null;
+
+class FL {
+  d: Doc; t: Trace; sel: string; scope: "page" | "card" | "menu"; idx: number | null = null;
+  hasTextFilter: string | RegExp | null = null;
+  constructor(d: Doc, t: Trace, sel: string, scope: FL["scope"] = "page") { this.d = d; this.t = t; this.sel = sel; this.scope = scope; }
+  private clone(): FL { const l = new FL(this.d, this.t, this.sel, this.scope); l.idx = this.idx; l.hasTextFilter = this.hasTextFilter; return l; }
+  first(): FL { const l = this.clone(); l.idx = 0; return l; }
+  nth(i: number): FL { const l = this.clone(); l.idx = i; return l; }
+  filter(o?: { hasText?: string | RegExp }): FL { const l = this.clone(); if (o?.hasText !== undefined) l.hasTextFilter = o.hasText; return l; }
+  locator(sel: string, o?: { hasText?: string | RegExp }): FL {
+    const n = this.resolve()[0];
+    const scope: FL["scope"] = n?.k === "menu" ? "menu" : n?.k === "card" ? "card" : this.scope;
+    const l = new FL(this.d, this.t, sel, scope);
+    if (o?.hasText !== undefined) l.hasTextFilter = o.hasText;
+    return l;
+  }
+
+  /** One selector alternative vs one menu item. Models the REAL nested-label DOM. */
+  private itemMatch(part: string, it: Item): boolean {
+    if (!part.includes("menuitem")) return false;
+    // :text-is() targets the element's own text; the real label is nested, so it never matches.
+    if (/:text-is\(/.test(part)) return false;
+    if (/:has-text\(/.test(part)) {
+      const v = part.match(/:has-text\((?:"([^"]*)"|'([^']*)')\)/)?.slice(1).find(Boolean) ?? "";
+      return norm(it.text).toLowerCase().includes(v.toLowerCase());
+    }
+    const aria = attrSub(part, "aria-label");
+    if (aria !== null) return false; // every real menu item has aria-label = null
+    const hrefSubs = [...part.matchAll(/\[href\*=["']([^"']+)["']\]/g)].map(m => m[1]);
+    if (hrefSubs.length) return hrefSubs.every(s => (it.href ?? "").includes(s));
+    const ckSuffix = attrSuffix(part, "componentkey");
+    if (ckSuffix !== null) return (it.componentkey ?? "").endsWith(ckSuffix);
+    const ckSub = attrSub(part, "componentkey");
+    if (ckSub !== null) return (it.componentkey ?? "").includes(ckSub);
+    return true; // bare [role="menuitem"]
+  }
+
+  private resolve(): N[] {
+    const out: N[] = [];
+    for (const part of this.sel.split(/,(?![^()]*\))/).map(s => s.trim())) {
+      if (part.includes("menuitem")) {
+        if (this.scope !== "menu") continue;            // menu items only exist inside the opened menu
+        for (const it of this.d.menuItems) if (this.itemMatch(part, it)) out.push({ k: "item", it });
+        continue;
+      }
+      if (part.includes('role="menu"')) {
+        if (this.d.menuOpens) { out.push({ k: "menu" }); for (let i = 0; i < this.d.extraVisibleMenus; i++) out.push({ k: "menu" }); }
+        continue;
+      }
+      if (/aria-label/.test(part) && /More/.test(part)) {
+        const pool = this.scope === "card" ? this.d.mores.filter(m => m.inCard) : this.d.mores;
+        for (const b of pool) {
+          const ex = part.match(/\[aria-label=["']([^"']+)["']/)?.[1];
+          const pre = part.match(/\[aria-label\^=["']([^"']+)["']/)?.[1];
+          if ((ex && b.aria === ex) || (pre && b.aria.startsWith(pre))) out.push({ k: "more", b });
+        }
+        continue;
+      }
+      if (part.includes("custom-invite")) {
+        const subs = [...part.matchAll(/\[href\*=["']([^"']+)["']\]/g)].map(m => m[1]);
+        const h = this.d.ownConnectHref;
+        if (h && subs.every(s => h.includes(s))) out.push({ k: "anchor", href: h });
+        continue;
+      }
+      if (part.includes("to connect")) { if (this.scope === "card" && this.d.cardConnectCta) out.push({ k: "anchor", href: connectHref(VANITY) }); continue; }
+      if (part.includes("/messaging/compose")) { if (this.scope === "card" && this.d.composeHref) out.push({ k: "anchor", href: this.d.composeHref }); continue; }
+      if (/Pending/.test(part)) { if (this.d.cardPending && (this.scope === "card" || this.scope === "page")) out.push({ k: "pending" }); continue; }
+      if (part.includes("Send without") || part.includes("Send now") || part.includes("Send invitation")) {
+        if (this.d.sendButtonAfterConnect && this.t.clicked.some(c => c.startsWith("Connect"))) out.push({ k: "send" });
+        continue;
+      }
+      if (/^p(:visible)?$/.test(part)) {
+        if (this.scope !== "card") continue;                 // badge lookups are card-scoped
+        const wantVisible = part.includes(":visible");
+        for (const q of this.d.paras) if (!wantVisible || q.visible) out.push({ k: "para", text: q.text });
+        continue;
+      }
+      if (part.includes('componentkey$="Topcard"')) { if (this.d.hasTopCard) out.push({ k: "card" }); continue; }
+      if (part.includes("msg-connections-typeahead")) { this.t.typeahead = true; continue; }
+    }
+    let res = out;
+    if (this.hasTextFilter !== null) {
+      const f = this.hasTextFilter;
+      const textOf = (n: N): string | null => n.k === "item" ? norm(n.it.text) : n.k === "para" ? norm(n.text) : null;
+      res = res.filter(n => {
+        const t = textOf(n);
+        return t !== null && (typeof f === "string" ? t.includes(f) : f.test(t));
+      });
+    }
+    return this.idx === null ? res : (res[this.idx] ? [res[this.idx]] : []);
+  }
+
+  async count(): Promise<number> { return this.resolve().length; }
+  async isVisible(): Promise<boolean> { return this.resolve().length > 0; }
+  async waitFor(): Promise<void> { if (this.resolve().length === 0) throw new Error(`Timeout ${this.sel}`); }
+  async evaluate(): Promise<unknown> { return undefined; }
+  async getAttribute(n: string): Promise<string | null> {
+    const x = this.resolve()[0]; if (!x) return null;
+    if (x.k === "anchor" && n === "href") return x.href;
+    if (x.k === "item" && n === "href") return x.it.href ?? null;
+    if (x.k === "item" && n === "componentkey") return x.it.componentkey ?? null;
+    if (x.k === "item" && n === "aria-label") return null;      // real DOM
+    if (x.k === "more" && n === "aria-controls") return null;   // real DOM
+    if (x.k === "menu" && n === "id") return null;              // real DOM
+    return null;
+  }
+  async innerText(): Promise<string> {
+    const x = this.resolve()[0];
+    if (x?.k === "para") return x.text;
+    if (x?.k === "item") return x.it.text;
+    if (this.scope === "card" || this.sel.includes('componentkey$="Topcard"')) {
+      if (!this.d.hasTopCard) throw new Error("no top card");
+      return this.d.cardText;
+    }
+    return "";
+  }
+  async click(): Promise<void> {
+    const x = this.resolve()[0];
+    if (!x) throw new Error(`cannot click ${this.sel}`);
+    if (x.k === "more") { this.t.clicked.push(`More(${x.b.inCard ? "card" : "other"})`); return; }
+    if (x.k === "item") { this.t.clicked.push(norm(x.it.text)); return; }
+    this.t.clicked.push(this.sel);
+  }
+  async type(): Promise<void> {}
+}
+
+class FP {
+  d: Doc; t: Trace;
+  constructor(d: Doc, t: Trace) { this.d = d; this.t = t; }
+  url(): string { return URL; }
+  async goto(u: string): Promise<void> { if (/thread\/new/.test(u)) this.t.typeahead = true; }
+  async waitForTimeout(): Promise<void> {}
+  locator(sel: string, o?: { hasText?: string | RegExp }): FL {
+    if (sel.includes("msg-connections-typeahead")) this.t.typeahead = true;
+    const l = new FL(this.d, this.t, sel, "page");
+    if (o?.hasText !== undefined) l.hasTextFilter = o.hasText;
+    return l;
+  }
+  on(): void {}
+}
+
+function mk(d: Partial<Doc> = {}) {
+  const dd = doc(d); const t: Trace = { clicked: [], typeahead: false };
+  return { page: new FP(dd, t) as unknown as Page, d: dd, t };
+}
+const card = async (p: Page): Promise<Locator | null> => findTopCard(p);
+const CARD_MORE: MoreBtn = { aria: "More", inCard: true };
+const NAV_MORE: MoreBtn = { aria: "More", inCard: false };
+const CONNECT_ITEM = { text: "Connect", href: connectHref(VANITY), componentkey: "ConnectButtonstate:invitation:urn:li:member:965635578_connect" };
+const REAL_MENU = [
+  { text: "Send profile in a message", href: "/messaging/compose/?screenContext=NON_SELF_PROFILE_VIEW&body=x" },
+  { text: "Save to PDF" },
+  CONNECT_ITEM,
+  { text: "Report / Block", href: "/preload/report-in-modal/?entityUrn=x" },
+  { text: "About this member", href: URL },
+];
+
+// ════ CONNECT-STATE TESTS ════
+
+test("T1 Follow-primary: Follow+Message+More, Connect in menu → connectable", async () => {
+  const { page } = mk({ cardText: "Diana C. Follow Message More", mores: [CARD_MORE], menuItems: REAL_MENU });
+  const c = await card(page);
+  await assert.doesNotReject(() => assertConnectable(page, c, VANITY));
+});
+
+test("T2 Follow-primary with profileUrn compose link → still connectable", async () => {
+  const { page } = mk({ cardText: "Diana C. Follow Message More", composeHref: COMPOSE_HREF, mores: [CARD_MORE], menuItems: REAL_MENU });
+  const c = await card(page);
+  await assert.doesNotReject(() => assertConnectable(page, c, VANITY));
+});
+
+test("T3 explicit 1st-degree indicator → AlreadyConnectedError", async () => {
+  const { page } = mk({ cardText: "Demo Investor · 1st · Message", paras: [{ text: "· 1st", visible: true }] });
+  const c = await card(page);
+  await assert.rejects(() => assertConnectable(page, c, VANITY), AlreadyConnectedError);
+});
+
+test("T4 1st-degree is decided by the '1st' indicator, not by profileUrn", async () => {
+  const withBoth = mk({ cardText: "Demo Investor · 1st · Message", paras: [{ text: "· 1st", visible: true }], composeHref: COMPOSE_HREF });
+  const cBoth = await card(withBoth.page);
+  await assert.rejects(() => assertConnectable(withBoth.page, cBoth, VANITY), AlreadyConnectedError);
+  // same compose link, no 1st indicator → must NOT be connected
+  const urnOnly = mk({ cardText: "Diana C. Follow Message", composeHref: COMPOSE_HREF });
+  const cUrn = await card(urnOnly.page);
+  await assert.doesNotReject(() => assertConnectable(urnOnly.page, cUrn, VANITY),
+    "profileUrn alone must never imply a connection");
+});
+
+test("T5 non-connected + profileUrn + Connect available → connectable (core Slice A regression)", async () => {
+  const { page } = mk({ cardText: "Diana C. Follow Message More", composeHref: COMPOSE_HREF, ownConnectHref: connectHref(VANITY) });
+  const c = await card(page);
+  await assert.doesNotReject(() => assertConnectable(page, c, VANITY));
+});
+
+test("T6 pending → PendingInviteError, nothing clicked", async () => {
+  const { page, t } = mk({ cardText: "Diana C. Pending Message", cardPending: true });
+  const c = await card(page);
+  await assert.rejects(() => assertConnectable(page, c, VANITY), PendingInviteError);
+  assert.deepEqual(t.clicked, []);
+});
+
+test("T7 More menu offers 'Remove connection' → AlreadyConnectedError, zero clicks", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: [{ text: "Message" }, { text: "Remove connection" }] });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), AlreadyConnectedError);
+  assert.deepEqual(t.clicked.filter(c => !c.startsWith("More(")), [], `no menu item may be clicked, got ${JSON.stringify(t.clicked)}`);
+});
+
+test("T8 'Connections' is not a connection signal", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: [{ text: "Connections" }, { text: "Save to PDF" }] });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), InviteUiError);
+  assert.ok(!t.clicked.some(c => /Connection/i.test(c)));
+});
+
+test("T9 'Remove connection' + 'Connect' together → AlreadyConnectedError, zero clicks", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: [{ text: "Remove connection" }, CONNECT_ITEM] });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), AlreadyConnectedError);
+  assert.deepEqual(t.clicked.filter(c => !c.startsWith("More(")), []);
+});
+
+// ════ MORE-BUTTON TESTS ════
+
+test("T10 multiple page-wide More buttons → the card's is used, never a positional guess", async () => {
+  const { page, t } = mk({ mores: [NAV_MORE, NAV_MORE, CARD_MORE], menuItems: REAL_MENU });
+  await openInviteDialog(page, URL, VANITY);
+  assert.ok(t.clicked.includes("More(card)"), `must open the card's More, got ${JSON.stringify(t.clicked)}`);
+  assert.ok(!t.clicked.includes("More(other)"), "must never open another More");
+});
+
+test("T11 no More button in the top card → InviteUiError, no click", async () => {
+  const { page, t } = mk({ mores: [NAV_MORE], menuItems: REAL_MENU });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), InviteUiError);
+  assert.deepEqual(t.clicked, []);
+});
+
+test("T12 multiple visible menus with no aria-controls → InviteUiError, no guess", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: REAL_MENU, extraVisibleMenus: 2 });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), InviteUiError);
+  assert.ok(!t.clicked.some(c => c === "Connect"));
+});
+
+// ════ MENU CONNECT SELECTOR TESTS ════
+
+test("T13 realistic Connect item (nested label, aria-label null, invite href) is discovered", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: REAL_MENU });
+  await openInviteDialog(page, URL, VANITY);
+  assert.ok(t.clicked.includes("Connect"), `Connect must be clicked, got ${JSON.stringify(t.clicked)}`);
+});
+
+test("T14 the Connect selector does not match 'Remove connection'", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: [{ text: "Remove connection" }] });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY));
+  assert.ok(!t.clicked.includes("Remove connection"));
+});
+
+test("T15 the Connect selector does not match 'Connections'", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: [{ text: "Connections" }] });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), InviteUiError);
+  assert.ok(!t.clicked.includes("Connections"));
+});
+
+test("T16 another person's Connect item is ignored", async () => {
+  const { page, t } = mk({
+    mores: [CARD_MORE],
+    menuItems: [{ text: "Connect", href: connectHref("some-other-person"), componentkey: "ConnectButtonstate:invitation:urn:li:member:999_connect" }],
+  });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), InviteUiError);
+  assert.deepEqual(t.clicked.filter(c => !c.startsWith("More(")), [], "a stranger's Connect must never be clicked");
+});
+
+// ════ VISIT / MESSAGE TESTS ════
+
+test("T17 non-connected + profileUrn compose link → isFirstDegree false", async () => {
+  const { page } = mk({ cardText: "Diana C. Follow Message", composeHref: COMPOSE_HREF });
+  assert.deepEqual(await visitProfile(page, URL), { degree: "not_first_degree", isFirstDegree: false, messagingUrn: null });
+});
+
+test("T18 confirmed 1st-degree → isFirstDegree true, URN extracted", async () => {
+  const { page } = mk({ cardText: "Demo Investor · 1st · Message", paras: [{ text: "· 1st", visible: true }], composeHref: COMPOSE_HREF });
+  const r = await visitProfile(page, URL);
+  assert.equal(r.isFirstDegree, true);
+  assert.equal(r.messagingUrn, "urn:li:fsd_profile:ACoAADmObfoB");
+});
+
+test("T19 non-connected → sendMessage throws NotConnectedError, typeahead never invoked", async () => {
+  const { page, t } = mk({ cardText: "Diana C. Follow Message", composeHref: COMPOSE_HREF });
+  await assert.rejects(() => message.sendMessage(page, "raise-faster", "hi", URL, null), message.NotConnectedError);
+  assert.equal(t.typeahead, false, "name-search typeahead must be unreachable");
+});
+
+test("T20 connected but no resolvable URN → safe error, never typeahead", async () => {
+  const { page, t } = mk({ cardText: "Demo Investor · 1st · connected", composeHref: null });
+  await assert.rejects(() => message.sendMessage(page, "Demo Investor", "hi", URL, null));
+  assert.equal(t.typeahead, false, "must never fall back to searching by name");
+});
+
+// ── absorbed from the retired Slice B suite (its fake modelled aria-labels the
+//    real DOM does not have; these scenarios re-expressed against real markup) ──
+
+test("T21 an exact Pending item in the More menu → PendingInviteError, zero clicks", async () => {
+  const { page, t } = mk({
+    mores: [CARD_MORE],
+    menuItems: [{ text: "Pending", componentkey: "ConnectButtonstate:invitation:urn:li:member:965635578_pending" }, { text: "Message" }],
+  });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), PendingInviteError);
+  assert.deepEqual(t.clicked.filter(c => !c.startsWith("More(")), []);
+});
+
+test("T22 a More button that opens no menu → InviteUiError, no Connect click", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: REAL_MENU, menuOpens: false });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), InviteUiError);
+  assert.ok(!t.clicked.includes("Connect"));
+});
+
+test("T23 when Connect is in the main card, the More menu is never opened", async () => {
+  const { page, t } = mk({
+    ownConnectHref: connectHref(VANITY),
+    mores: [CARD_MORE],
+    menuItems: REAL_MENU,
+    sendButtonAfterConnect: false,
+  });
+  await openInviteDialog(page, URL, VANITY).catch(() => { /* no send button; irrelevant here */ });
+  assert.ok(!t.clicked.some(c => c.startsWith("More(")), `More must not be opened, got ${JSON.stringify(t.clicked)}`);
+});
+
+// ════ DEGREE BADGE — real DOM contract ════
+// Observed live: a connected card renders <p>· 1st</p> as its own element, with
+// a HIDDEN <p>· 2nd</p> beside it. A non-connected card has no degree element
+// at all. Headlines/company/location live in their own, longer <p>s — which is
+// why anchoring to a whole element defeats "1st Round Capital" and friends.
+
+const BADGE_1ST = { text: "· 1st", visible: true };
+const BADGE_2ND_HIDDEN = { text: "· 2nd", visible: false };
+const NAME_P = { text: "Demo Investor", visible: true };
+
+test("T24 visible <p>· 1st</p> → first-degree", async () => {
+  const { page } = mk({ cardText: "Demo Investor · 1st Investor at Freelance", paras: [NAME_P, BADGE_1ST, BADGE_2ND_HIDDEN] });
+  const c = await card(page);
+  await assert.rejects(() => assertConnectable(page, c, VANITY), AlreadyConnectedError);
+  assert.equal((await visitProfile(page, URL)).isFirstDegree, true);
+});
+
+test("T25 HIDDEN <p>· 1st</p> → NOT first-degree", async () => {
+  // LinkedIn ships inapplicable degree variants hidden; a hidden badge is not a
+  // connection.
+  const { page } = mk({ cardText: "Someone · 1st", paras: [NAME_P, { text: "· 1st", visible: false }] });
+  const c = await card(page);
+  await assert.doesNotReject(() => assertConnectable(page, c, VANITY));
+  assert.equal((await visitProfile(page, URL)).isFirstDegree, false);
+});
+
+test("T26 visible <p>· 2nd</p> only → NOT first-degree", async () => {
+  const { page } = mk({ cardText: "Someone · 2nd", paras: [NAME_P, { text: "· 2nd", visible: true }] });
+  const c = await card(page);
+  await assert.doesNotReject(() => assertConnectable(page, c, VANITY));
+  assert.equal((await visitProfile(page, URL)).isFirstDegree, false);
+});
+
+for (const headline of ["Partner at 1st Round Capital London", "1st Lieutenant, US Army", "Ranked 1st in EMEA sales 2025"]) {
+  test(`T27 headline "${headline}" → NOT first-degree`, async () => {
+    const { page } = mk({
+      cardText: `Jane Doe ${headline} Follow Message`,
+      paras: [{ text: "Jane Doe", visible: true }, { text: headline, visible: true }],
+    });
+    const c = await card(page);
+    await assert.doesNotReject(() => assertConnectable(page, c, VANITY),
+      "arbitrary '1st' in a headline must never imply a connection");
+    assert.equal((await visitProfile(page, URL)).isFirstDegree, false);
+  });
+}
+
+test("T28 compose profileUrn WITHOUT a degree badge → NOT first-degree", async () => {
+  const { page } = mk({ cardText: "Diana C. Follow Message", paras: [NAME_P], composeHref: COMPOSE_HREF });
+  assert.deepEqual(await visitProfile(page, URL), { degree: "not_first_degree", isFirstDegree: false, messagingUrn: null });
+});
+
+test("T29 compose profileUrn WITH a degree badge → first-degree + URN", async () => {
+  const { page } = mk({ cardText: "Demo Investor · 1st", paras: [NAME_P, BADGE_1ST], composeHref: COMPOSE_HREF });
+  const r = await visitProfile(page, URL);
+  assert.equal(r.isFirstDegree, true);
+  assert.equal(r.messagingUrn, "urn:li:fsd_profile:ACoAADmObfoB");
+});
+
+test("T30 no degree evidence and no Connect/Remove/Pending → InviteUiError", async () => {
+  const { page, t } = mk({ cardText: "Diana C. Follow Message", paras: [NAME_P], mores: [CARD_MORE], menuItems: [{ text: "Save to PDF" }] });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), InviteUiError);
+  assert.deepEqual(t.clicked.filter(c => !c.startsWith("More(")), []);
+});
+
+test("T31 Pending + Connect in the menu → PendingInviteError, zero clicks", async () => {
+  const { page, t } = mk({ mores: [CARD_MORE], menuItems: [{ text: "Pending" }, CONNECT_ITEM] });
+  await assert.rejects(() => openInviteDialog(page, URL, VANITY), PendingInviteError);
+  assert.deepEqual(t.clicked.filter(c => !c.startsWith("More(")), []);
+});

--- a/tests/visit-degree-observation.test.ts
+++ b/tests/visit-degree-observation.test.ts
@@ -1,0 +1,228 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "playwright";
+
+const { visitProfile } = await import("@/lib/linkedin/visit");
+
+const URL = "https://www.linkedin.com/in/someone-123/";
+const URN = "urn:li:fsd_profile:ACoAADummyObservation";
+const composeHref = `/messaging/compose/?profileUrn=${encodeURIComponent(URN)}&recipient=x&screenContext=NON_SELF_PROFILE_VIEW`;
+
+// ─── fake page ───────────────────────────────────────────────────────────────
+// The degree contract is element-level and visibility-sensitive, so the fake
+// models paragraphs as { text, visible } pairs rather than as a count or a blob
+// of card text. That is what makes "hidden · 1st" and "visible · 2nd" genuinely
+// distinguishable here instead of accidentally passing:
+//   - `p:visible` must drop hidden paragraphs (a connected card really does
+//     ship a hidden `· 2nd` next to the visible `· 1st`);
+//   - filter({hasText: /^·?\s*1st$/}) is anchored per element, so prose such as
+//     "Partner at 1st Round Capital" must not match even though it contains
+//     "1st";
+//   - the card's own innerText is deliberately NOT consulted by the production
+//     code, so this fake exposes it while keeping it irrelevant.
+
+interface Para { text: string; visible: boolean }
+interface Doc {
+  hasTopCard: boolean;
+  paras: Para[];
+  composeHref: string | null;
+}
+
+const visible = (text: string): Para => ({ text, visible: true });
+const hidden = (text: string): Para => ({ text, visible: false });
+
+class FL {
+  // Explicit fields, not constructor parameter properties: Node's strip-only
+  // TypeScript mode rejects those outright (ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX).
+  d: Doc;
+  sel: string;
+  scope: "page" | "card";
+  hasText: string | RegExp | null;
+  constructor(d: Doc, sel: string, scope: "page" | "card", hasText: string | RegExp | null = null) {
+    this.d = d; this.sel = sel; this.scope = scope; this.hasText = hasText;
+  }
+  first(): FL { return this; }
+  filter(o?: { hasText?: string | RegExp }): FL {
+    return o?.hasText === undefined ? this : new FL(this.d, this.sel, this.scope, o.hasText);
+  }
+  locator(sel: string): FL {
+    // Only the top-card locator yields card scope; anything else stays page-wide.
+    return new FL(this.d, sel, this.sel.includes('componentkey$="Topcard"') ? "card" : this.scope);
+  }
+  private paraMatches(): number {
+    if (this.scope !== "card") return 0;
+    const onlyVisible = this.sel.endsWith(":visible");
+    return this.d.paras.filter(p => {
+      if (onlyVisible && !p.visible) return false;
+      const n = p.text.replace(/\s+/g, " ").trim();
+      if (this.hasText === null) return true;
+      return typeof this.hasText === "string" ? n.includes(this.hasText) : this.hasText.test(n);
+    }).length;
+  }
+  private matches(): number {
+    if (this.sel.includes('componentkey$="Topcard"')) return this.d.hasTopCard ? 1 : 0;
+    if (this.sel.startsWith("main section")) return 0;              // legacy layout absent
+    if (this.sel === "p" || this.sel === "p:visible") return this.paraMatches();
+    if (this.sel.includes("/messaging/compose")) return this.scope === "card" && this.d.composeHref ? 1 : 0;
+    return 0;
+  }
+  async count(): Promise<number> { return this.matches(); }
+  async getAttribute(n: string): Promise<string | null> {
+    return n === "href" && this.scope === "card" && this.sel.includes("/messaging/compose")
+      ? this.d.composeHref
+      : null;
+  }
+  async innerText(): Promise<string> {
+    return this.scope === "card" || this.sel.includes('componentkey$="Topcard"')
+      ? this.d.paras.map(p => p.text).join(" ")
+      : "";
+  }
+}
+
+class FP {
+  d: Doc;
+  constructor(d: Doc) { this.d = d; }
+  url(): string { return URL; }
+  async goto(): Promise<void> {}
+  async waitForTimeout(): Promise<void> {}
+  locator(sel: string): FL { return new FL(this.d, sel, "page"); }
+}
+
+const mk = (d: Partial<Doc> = {}): Page =>
+  new FP({ hasTopCard: true, paras: [], composeHref: null, ...d }) as unknown as Page;
+
+// ─── fake fidelity ───────────────────────────────────────────────────────────
+// If these fail, every assertion below is meaningless.
+
+test("fake: p:visible excludes hidden paragraphs", async () => {
+  const page = mk({ paras: [hidden("· 1st"), visible("· 2nd")] });
+  const card = new FL({ hasTopCard: true, paras: [hidden("· 1st"), visible("· 2nd")], composeHref: null },
+    '[componentkey$="Topcard"]', "page");
+  assert.equal(await card.locator("p:visible").count(), 1, "only the visible paragraph may match");
+  assert.equal(await card.locator("p").count(), 2, "unfiltered `p` must still see both");
+  assert.ok(page);
+});
+
+test("fake: hasText filtering is anchored per element, not substring over the card", async () => {
+  const card = new FL(
+    { hasTopCard: true, paras: [visible("Partner at 1st Round Capital")], composeHref: null },
+    '[componentkey$="Topcard"]', "page",
+  );
+  assert.equal(await card.locator("p:visible").filter({ hasText: /^·?\s*1st$/ }).count(), 0);
+  assert.equal(await card.locator("p:visible").filter({ hasText: "1st" }).count(), 1,
+    "a substring filter WOULD match — proving the anchored regex is what saves us");
+});
+
+// ─── A. top card absent → inconclusive ───────────────────────────────────────
+
+test("A no top card → inconclusive, not a negative observation", async () => {
+  const r = await visitProfile(mk({ hasTopCard: false, composeHref }), URL);
+
+  assert.deepEqual(r, { degree: "inconclusive", isFirstDegree: false, messagingUrn: null });
+});
+
+test("A2 inconclusive is returned even when compose links exist page-wide", async () => {
+  // A sidebar full of other people's compose links must not upgrade the
+  // observation: without the card there is nothing to observe.
+  const r = await visitProfile(mk({ hasTopCard: false, paras: [visible("· 1st")], composeHref }), URL);
+
+  assert.equal(r.degree, "inconclusive");
+});
+
+// ─── B. visible 1st badge → first_degree ─────────────────────────────────────
+
+test("B visible '· 1st' badge → first_degree with the URN extracted", async () => {
+  const r = await visitProfile(mk({ paras: [visible("Someone"), visible("· 1st")], composeHref }), URL);
+
+  assert.deepEqual(r, { degree: "first_degree", isFirstDegree: true, messagingUrn: URN });
+});
+
+test("B2 first_degree with no compose link → connected, URN null", async () => {
+  const r = await visitProfile(mk({ paras: [visible("· 1st")], composeHref: null }), URL);
+
+  assert.deepEqual(r, { degree: "first_degree", isFirstDegree: true, messagingUrn: null });
+});
+
+test("B3 the real connected card — visible '· 1st' beside a hidden '· 2nd'", async () => {
+  // Exactly what the live DOM ships (verified Aug 2026).
+  const r = await visitProfile(mk({ paras: [visible("· 1st"), hidden("· 2nd")], composeHref }), URL);
+
+  assert.equal(r.degree, "first_degree");
+});
+
+// ─── C. card found, no badge → not_first_degree ──────────────────────────────
+
+test("C card found with no degree badge → not_first_degree", async () => {
+  const r = await visitProfile(mk({ paras: [visible("Someone"), visible("Follow"), visible("Message")], composeHref }), URL);
+
+  assert.deepEqual(r, { degree: "not_first_degree", isFirstDegree: false, messagingUrn: null });
+});
+
+test("C2 a profileUrn compose link is never promoted to a connection", async () => {
+  // /in/raise-faster/ (NOT connected) and a confirmed 1st-degree both render
+  // structurally identical profileUrn compose links.
+  const r = await visitProfile(mk({ paras: [visible("Raise Faster"), visible("Message")], composeHref }), URL);
+
+  assert.equal(r.degree, "not_first_degree");
+  assert.equal(r.messagingUrn, null, "no URN may leak out of a non-connection");
+});
+
+// ─── D. hidden 1st badge → not_first_degree ──────────────────────────────────
+
+test("D a HIDDEN '· 1st' does not count", async () => {
+  const r = await visitProfile(mk({ paras: [visible("· 2nd"), hidden("· 1st")], composeHref }), URL);
+
+  assert.equal(r.degree, "not_first_degree");
+  assert.equal(r.messagingUrn, null);
+});
+
+// ─── E. visible 2nd badge → not_first_degree ─────────────────────────────────
+
+test("E a visible '· 2nd' badge → not_first_degree", async () => {
+  const r = await visitProfile(mk({ paras: [visible("Someone"), visible("· 2nd")], composeHref }), URL);
+
+  assert.equal(r.degree, "not_first_degree");
+});
+
+test("E2 '· 3rd' likewise", async () => {
+  const r = await visitProfile(mk({ paras: [visible("· 3rd")], composeHref }), URL);
+
+  assert.equal(r.degree, "not_first_degree");
+});
+
+// ─── F. prose containing "1st" → not_first_degree ────────────────────────────
+
+test("F prose containing '1st' is not a badge", async () => {
+  for (const prose of [
+    "Partner at 1st Round Capital",
+    "1st Lieutenant, US Army",
+    "Ranked 1st in EMEA",
+    "1st",                              // control: this one IS badge-shaped
+  ]) {
+    const r = await visitProfile(mk({ paras: [visible(prose)], composeHref }), URL);
+    const expected = prose === "1st" ? "first_degree" : "not_first_degree";
+    assert.equal(r.degree, expected, `"${prose}" should be ${expected}`);
+  }
+});
+
+// ─── invariants ──────────────────────────────────────────────────────────────
+
+test("isFirstDegree is true for first_degree only — both negatives fail closed", async () => {
+  const cases: Array<[Partial<Doc>, string, boolean]> = [
+    [{ hasTopCard: false }, "inconclusive", false],
+    [{ paras: [visible("Follow")] }, "not_first_degree", false],
+    [{ paras: [visible("· 1st")] }, "first_degree", true],
+  ];
+  for (const [doc, degree, isFirstDegree] of cases) {
+    const r = await visitProfile(mk({ composeHref, ...doc }), URL);
+    assert.equal(r.degree, degree);
+    assert.equal(r.isFirstDegree, isFirstDegree, `isFirstDegree must be ${isFirstDegree} for ${degree}`);
+  }
+});
+
+test("a URN is returned only alongside first_degree", async () => {
+  for (const doc of [{ hasTopCard: false }, { paras: [visible("Message")] }, { paras: [hidden("· 1st")] }]) {
+    const r = await visitProfile(mk({ composeHref, ...doc }), URL);
+    assert.equal(r.messagingUrn, null, `${r.degree} must not carry a URN`);
+  }
+});

--- a/tests/visit-topcard.test.ts
+++ b/tests/visit-topcard.test.ts
@@ -1,0 +1,213 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { Page } from "playwright";
+
+const { visitProfile } = await import("@/lib/linkedin/visit");
+const { sendMessage, NotConnectedError } = await import("@/lib/linkedin/message");
+
+const URL = "https://www.linkedin.com/in/vivi-undefined-b08a99423/";
+
+// ─── fake page ───────────────────────────────────────────────────────────────
+// Models only what findTopCard() and visitProfile() actually query:
+//  - the SDUI card, matched by [componentkey$="Topcard"];
+//  - the legacy card, matched by `main section` filtered on a nested <h1>;
+//  - the compose link scoped INSIDE whichever card was found.
+// "none" reproduces the live regression: an SDUI page seen through the old
+// <h1>-only locator, where nothing matches at all.
+
+type Layout = "sdui" | "legacy" | "none";
+
+interface ProfileState {
+  layout: Layout;
+  /** visible <p> elements in the card; the degree badge is <p>· 1st</p> */
+  paras: string[];
+  /** text of the target's own top card */
+  topCardText: string;
+  /** href of the compose link inside the target's own card, if any */
+  composeHref: string | null;
+}
+
+type Kind = "sduiCard" | "mainSection" | "compose" | "para" | "other";
+
+class FakeLocator {
+  st: ProfileState;
+  kind: Kind;
+  filtered: boolean;
+  parentExists = false;
+  constructor(st: ProfileState, kind: Kind, filtered = false) {
+    this.st = st;
+    this.kind = kind;
+    this.filtered = filtered;
+  }
+  /** Does this card locator actually match anything on this layout? */
+  private cardExists(): boolean {
+    if (this.kind === "sduiCard") return this.st.layout === "sdui";
+    // the legacy card only matches once filtered on its nested <h1>
+    if (this.kind === "mainSection") return this.filtered && this.st.layout === "legacy";
+    return false;
+  }
+  hasText: string | RegExp | null = null;
+  first(): FakeLocator { return this; }
+  filter(o?: { hasText?: string | RegExp }): FakeLocator {
+    if (o?.hasText === undefined) return new FakeLocator(this.st, this.kind, true);
+    const l = new FakeLocator(this.st, this.kind, this.filtered);
+    l.parentExists = this.parentExists; l.hasText = o.hasText; return l;
+  }
+  locator(sel: string): FakeLocator {
+    // Scoped lookups inherit their parent: a card that matched nothing cannot
+    // yield a compose link. This is what makes the old <h1>-only locator fail
+    // on an SDUI page instead of silently finding a link anyway.
+    if (sel.includes("/messaging/compose")) {
+      const child = new FakeLocator(this.st, "compose");
+      child.parentExists = this.cardExists();
+      return child;
+    }
+    if (sel === "p" || sel === "p:visible") {
+      const child = new FakeLocator(this.st, "para");
+      child.parentExists = this.cardExists();
+      return child;
+    }
+    return new FakeLocator(this.st, "other");
+  }
+  async count(): Promise<number> {
+    if (this.kind === "sduiCard" || this.kind === "mainSection") return this.cardExists() ? 1 : 0;
+    if (this.kind === "compose") return this.parentExists && this.st.composeHref ? 1 : 0;
+    if (this.kind === "para") {
+      if (!this.parentExists) return 0;
+      const f = this.hasText;
+      return this.st.paras.filter(t => {
+        const n = t.replace(/\s+/g, " ").trim();
+        return f === null ? true : typeof f === "string" ? n.includes(f) : f.test(n);
+      }).length;
+    }
+    return 0;
+  }
+  async getAttribute(name: string): Promise<string | null> {
+    if (this.kind !== "compose" || name !== "href") return null;
+    return this.parentExists ? this.st.composeHref : null;
+  }
+  async innerText(): Promise<string> {
+    if (this.kind === "sduiCard" || this.kind === "mainSection") {
+      // Playwright throws when the locator resolves to nothing.
+      if (!this.cardExists()) throw new Error("no top card");
+      return this.st.topCardText;
+    }
+    return "";
+  }
+}
+
+class FakePage {
+  st: ProfileState;
+  constructor(st: ProfileState) { this.st = st; }
+  async goto(): Promise<void> {}
+  async waitForTimeout(): Promise<void> {}
+  url(): string { return URL; }
+  locator(sel: string): FakeLocator {
+    if (sel.includes('componentkey$="Topcard"')) return new FakeLocator(this.st, "sduiCard");
+    if (sel === "main section") return new FakeLocator(this.st, "mainSection");
+    return new FakeLocator(this.st, "other");
+  }
+}
+
+const pageFor = (st: Partial<ProfileState>): Page =>
+  new FakePage({ layout: "sdui", topCardText: "", paras: [], composeHref: null, ...st }) as unknown as Page;
+
+const URN = "urn:li:fsd_profile:ACoAADummyUrn123";
+const composeHref = (urn: string) =>
+  `https://www.linkedin.com/messaging/compose/?profileUrn=${encodeURIComponent(urn)}&recipient=x`;
+
+// ─── (1) SDUI Topcard is recognised ──────────────────────────────────────────
+
+test("the SDUI Topcard layout is recognised", async () => {
+  // The live regression: this layout has no <h1>, so the old locator matched
+  // nothing and every connected target read as NOT connected.
+  const page = pageFor({ layout: "sdui", topCardText: "Vivi undefined 1st", paras: ["· 1st"], composeHref: composeHref(URN) });
+
+  const result = await visitProfile(page, URL);
+
+  assert.equal(result.isFirstDegree, true, "an SDUI card must be found, not silently missed");
+});
+
+// ─── (2) legacy layout still works ───────────────────────────────────────────
+
+test("the legacy `main section` + h1 layout is still recognised", async () => {
+  const page = pageFor({ layout: "legacy", topCardText: "Someone 1st", paras: ["· 1st"], composeHref: composeHref(URN) });
+
+  const result = await visitProfile(page, URL);
+
+  assert.equal(result.isFirstDegree, true);
+  assert.equal(result.messagingUrn, URN);
+});
+
+// ─── (3) connected SDUI profile ──────────────────────────────────────────────
+
+test("a connected SDUI profile returns isFirstDegree: true via the 1st badge", async () => {
+  const page = pageFor({ layout: "sdui", topCardText: "Vivi undefined · 1st", paras: ["· 1st"], composeHref: composeHref(URN) });
+
+  assert.deepEqual(await visitProfile(page, URL), { degree: "first_degree", isFirstDegree: true, messagingUrn: URN });
+});
+
+test("a '1st' badge with no compose link is first-degree with no URN", async () => {
+  // Slice C: the badge is the connection signal. No compose link means no URN,
+  // which is safe — sendMessage() raises MessagingUrnUnresolvedError rather
+  // than searching for a recipient by name.
+  const page = pageFor({ layout: "sdui", topCardText: "Vivi undefined · 1st · Mumbai", paras: ["· 1st"], composeHref: null });
+
+  assert.deepEqual(await visitProfile(page, URL), { degree: "first_degree", isFirstDegree: true, messagingUrn: null });
+});
+
+// ─── (4) non-connected profiles ──────────────────────────────────────────────
+
+test("a non-connected profile still returns isFirstDegree: false", async () => {
+  const page = pageFor({ layout: "sdui", topCardText: "Someone · 3rd · Connect", composeHref: null });
+
+  assert.deepEqual(await visitProfile(page, URL), { degree: "not_first_degree", isFirstDegree: false, messagingUrn: null });
+});
+
+test("no top card at all returns INCONCLUSIVE rather than throwing", async () => {
+  // Not a negative observation: nothing was inspected, so a stored degree=1
+  // must survive this. See tests/runner-visit-degree.test.ts case I.
+  const page = pageFor({ layout: "none", topCardText: "", composeHref: null });
+
+  assert.deepEqual(await visitProfile(page, URL), { degree: "inconclusive", isFirstDegree: false, messagingUrn: null });
+});
+
+// ─── (5) URN extraction is unchanged ─────────────────────────────────────────
+
+test("the messaging URN is decoded from the compose link's profileUrn param", async () => {
+  const page = pageFor({ layout: "sdui", topCardText: "x · 1st", paras: ["· 1st"], composeHref: composeHref(URN) });
+
+  assert.equal((await visitProfile(page, URL)).messagingUrn, URN, "must be URL-decoded");
+});
+
+test("a compose link without profileUrn is NOT first-degree", async () => {
+  // The raise-faster regression: a Follow-primary/non-connection profile renders
+  // a Message button whose href carries no profileUrn.
+  const page = pageFor({
+    layout: "sdui",
+    topCardText: "x",
+    composeHref: "https://www.linkedin.com/messaging/compose/?recipient=x",
+  });
+
+  assert.deepEqual(await visitProfile(page, URL), { degree: "not_first_degree", isFirstDegree: false, messagingUrn: null });
+});
+
+// ─── (6) sendMessage still refuses a genuine non-connection ──────────────────
+
+test("sendMessage refuses to message a genuinely non-1st-degree profile", async () => {
+  // The safety guard must survive the fix: a real non-connection must still
+  // raise NotConnectedError rather than falling through to the name-search
+  // typeahead, which is what messaged an unrelated person in Jul 2026.
+  const page = pageFor({ layout: "sdui", topCardText: "Someone · 3rd · Connect", composeHref: null });
+
+  await assert.rejects(
+    () => sendMessage(page, "Someone Else", "hello", URL, null),
+    NotConnectedError
+  );
+});
+
+test("sendMessage refuses when no top card can be resolved at all", async () => {
+  const page = pageFor({ layout: "none", topCardText: "", composeHref: null });
+
+  await assert.rejects(() => sendMessage(page, "Someone Else", "hello", URL, null), NotConnectedError);
+});


### PR DESCRIPTION
Connection detection is now driven by the visible degree badge on the target's own top card, replacing heuristics that read the compose link, profileUrn, or the card's prose — each of which marked non-connections as 1st-degree, skipped real invitations, and could authorise a message to the wrong person. Connect discovery handles the Follow-primary layout via the More menu, scoped by the target's vanityName so a stranger's menu item can never match.

Messaging now re-verifies the connection live before composing: a cached messaging URN is an address, never permission. The name-search typeahead fallback is removed rather than bypassed, so there is no path left that can pick a recipient by display name.

visitProfile() reports a three-state observation (first_degree / not_first_degree / inconclusive) so the runner can clear a stale degree=1 only on positive evidence, never when the card could not be inspected.

Also: atomic track claim with a lease so a step runs exactly once across restarts, PendingInviteError recovery to prevent duplicate invitations, enrolment spreading rebased to the current time, account deletion returning 409/404 instead of 500, and an unref'd update-check interval that no longer keeps the test process alive.


Claude-Session: https://claude.ai/code/session_01NoTpnr3sqVubrakxyWHKDV